### PR TITLE
Allow removal of the default logger

### DIFF
--- a/source/vibe/core/log.d
+++ b/source/vibe/core/log.d
@@ -754,7 +754,10 @@ private {
 	shared(FileLogger) ss_stdoutLogger;
 }
 
-private shared(Logger)[] getLoggers() nothrow @trusted { return ss_loggers; }
+/**
+Returns a list of all registered loggers.
+*/
+shared(Logger)[] getLoggers() nothrow @trusted { return ss_loggers; }
 
 package void initializeLogModule()
 {


### PR DESCRIPTION
Last week I discovered an imho important use case of `vibe.core.log`: I wanted to display more information on the default console logger (file name, line number, ...) and thought that I can just implement my own logger and deregister the default one. However, unfortunately deregistering the default logger isn't possible as no reference to it is exposed to the user.

An alternative to exposing `getLoggers`, would be to have a `deregisterAll` method.

Btw what is the reason for commenting `string mod = __MODULE__, string func = __FUNCTION__,`?
Did it add too much bloat to the compiled binary?