### PR TITLE
Use a thread local allocator instead of processAllocator in HashMap.

### DIFF
--- a/source/vibe/internal/allocator.d
+++ b/source/vibe/internal/allocator.d
@@ -7,3 +7,12 @@ public import std.experimental.allocator.building_blocks.region;
 public import std.experimental.allocator.building_blocks.stats_collector;
 public import std.experimental.allocator.gc_allocator;
 public import std.experimental.allocator.mallocator;
+
+// NOTE: this needs to be used instead of theAllocator due to Phobos issue 17564
+@property IAllocator vibeThreadAllocator()
+@safe nothrow @nogc {
+	static IAllocator s_threadAllocator;
+	if (!s_threadAllocator)
+		s_threadAllocator = () @trusted { return allocatorObject(GCAllocator.instance); } ();
+    return s_threadAllocator;
+}

--- a/source/vibe/internal/hashmap.d
+++ b/source/vibe/internal/hashmap.d
@@ -219,7 +219,7 @@ struct HashMap(TKey, TValue, Traits = DefaultHashMapTraits!TKey)
 		scope(exit) m_resizing = false;
 
 		if (!m_allocator) {
-			try m_allocator = processAllocator();
+			try m_allocator = vibeThreadAllocator();
 			catch (Exception e) assert(false, e.msg);
 		}
 


### PR DESCRIPTION
This is required since processAllocator returns an ISharedAlloactor since 2.075.0. Because HashMap is operating only thread-local, this should generally be safe.