### PR TITLE
Remove deprecated stdc import

### DIFF
--- a/source/vibe/core/core.d
+++ b/source/vibe/core/core.d
@@ -1264,7 +1264,7 @@ shared static this()
 		static if (need_wsa) {
 			logTrace("init winsock");
 			// initialize WinSock2
-			import std.c.windows.winsock;
+			import core.sys.windows.winsock2;
 			WSADATA data;
 			WSAStartup(0x0202, &data);
 

--- a/source/vibe/core/net.d
+++ b/source/vibe/core/net.d
@@ -34,7 +34,7 @@ NetworkAddress resolveHost(string host, AddressFamily address_family = AddressFa
 NetworkAddress resolveHost(string host, ushort address_family, bool use_dns = true)
 {
 	import std.socket : parseAddress;
-	version (Windows) import std.c.windows.winsock : sockaddr_in, sockaddr_in6;
+	version (Windows) import core.sys.windows.winsock2 : sockaddr_in, sockaddr_in6;
 	else import core.sys.posix.netinet.in_ : sockaddr_in, sockaddr_in6;
 
 	enforce(host.length > 0, "Host name must not be empty.");


### PR DESCRIPTION
Analogous to https://github.com/rejectedsoftware/vibe.d/pull/1811

> This was probably not seen because no developers actively compiles Vibe.d on Windows and looked at the deprecation warnings.

See also: https://github.com/dlang/phobos/pull/5532