### PR TITLE
Use abort() in case of uncaught Error exceptions.

### DIFF
--- a/source/vibe/core/task.d
+++ b/source/vibe/core/task.d
@@ -77,7 +77,7 @@ struct Task {
 		}
 
 		package @property ref ThreadInfo tidInfo() @system { return m_fiber ? taskFiber.tidInfo : s_tidInfo; } // FIXME: this is not thread safe!
-		
+
 		@property Tid tid() @trusted { return tidInfo.ident; }
 	}
 
@@ -346,7 +346,7 @@ final package class TaskFiber : Fiber {
 		import std.concurrency : Tid, thisTid;
 		import std.encoding : sanitize;
 		import vibe.core.core : isEventLoopRunning, recycleFiber, taskScheduler, yield;
-		
+
 		version (VibeDebugCatchAll) alias UncaughtException = Throwable;
 		else alias UncaughtException = Exception;
 		try {
@@ -416,13 +416,13 @@ final package class TaskFiber : Fiber {
 			logDiagnostic("Full error: %s", th.toString().sanitize());
 		} catch (Throwable th) {
 			import std.stdio : stderr, writeln;
-			import core.stdc.stdlib : exit;
+			import core.stdc.stdlib : abort;
 			try stderr.writeln(th);
 			catch (Exception e) {
 				try stderr.writeln(th.msg);
 				catch (Exception e) {}
 			}
-			exit(1);
+			abort();
 		}
 	}
 
@@ -521,7 +521,7 @@ package struct TaskFuncInfo {
 
 		import std.algorithm : move;
 		import std.traits : hasElaborateAssign;
-		import std.conv : to;	
+		import std.conv : to;
 
 		static struct TARGS { ARGS expand; }
 
@@ -745,7 +745,7 @@ package struct TaskScheduler {
 
 	/** Holds execution until the task gets explicitly resumed.
 
-		
+
 	*/
 	void hibernate()
 	{

--- a/source/vibe/core/taskpool.d
+++ b/source/vibe/core/taskpool.d
@@ -47,7 +47,7 @@ shared class TaskPool {
 			threads.length = thread_count;
 			foreach (i; 0 .. thread_count) {
 				WorkerThread thr;
-				() @trusted { 
+				() @trusted {
 					thr = new WorkerThread(this);
 					thr.name = format("vibe-%s", i);
 					thr.start();
@@ -237,7 +237,7 @@ private class WorkerThread : Thread {
 
 	private void main()
 	nothrow {
-		import core.stdc.stdlib : exit;
+		import core.stdc.stdlib : abort;
 		import core.exception : InvalidMemoryOperationError;
 		import std.encoding : sanitize;
 
@@ -249,19 +249,13 @@ private class WorkerThread : Thread {
 			if (!m_pool.m_state.lock.term) runEventLoop();
 			logDebug("Worker thread exit.");
 		} catch (Exception e) {
-			scope (failure) exit(-1);
+			scope (failure) abort();
 			logFatal("Worker thread terminated due to uncaught exception: %s", e.msg);
 			logDebug("Full error: %s", e.toString().sanitize());
-		} catch (InvalidMemoryOperationError e) {
-			import std.stdio;
-			scope(failure) assert(false);
-			writeln("Error message: ", e.msg);
-			writeln("Full error: ", e.toString().sanitize());
-			exit(-1);
 		} catch (Throwable th) {
 			logFatal("Worker thread terminated due to uncaught error: %s", th.msg);
 			logDebug("Full error: %s", th.toString().sanitize());
-			exit(-1);
+			abort();
 		}
 	}
 
@@ -338,7 +332,7 @@ nothrow @safe:
 	bool consume(ref TaskFuncInfo tfi)
 	{
 		import std.algorithm.mutation : swap;
-		
+
 		if (m_queue.empty) return false;
 		swap(tfi, m_queue.front);
 		m_queue.popFront();


### PR DESCRIPTION
Fixes "dwarfeh(224) fatal error" that are suspected to be related to occasional infinite loops.