### PR TITLE
fix deadlocks, caused by second m_locks increment

### DIFF
--- a/source/vibe/core/sync.d
+++ b/source/vibe/core/sync.d
@@ -216,7 +216,6 @@ final class LocalTaskSemaphore
 		while (true) {
 			m_signal.waitUninterruptible();
 			if (m_waiters.front.seq == w.seq && tryLock()) {
-				m_locks++;
 				return;
 			}
 		}


### PR DESCRIPTION
Got some nasty deadlocks in connection pool because of this.