### PR TITLE
Use the stable stdx-allocator DUB package

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -5,6 +5,7 @@ copyright "Copyright © 2016, rejectedsoftware e.K."
 license "MIT"
 
 dependency "eventcore" version="~>0.8.18"
+dependency "stdx-allocator" version="~>2.77.0"
 
 targetName "vibe_core"
 

--- a/source/vibe/internal/allocator.d
+++ b/source/vibe/internal/allocator.d
@@ -1,12 +1,12 @@
 module vibe.internal.allocator;
 
-public import std.experimental.allocator;
-public import std.experimental.allocator.building_blocks.allocator_list;
-public import std.experimental.allocator.building_blocks.null_allocator;
-public import std.experimental.allocator.building_blocks.region;
-public import std.experimental.allocator.building_blocks.stats_collector;
-public import std.experimental.allocator.gc_allocator;
-public import std.experimental.allocator.mallocator;
+public import stdx.allocator;
+public import stdx.allocator.building_blocks.allocator_list;
+public import stdx.allocator.building_blocks.null_allocator;
+public import stdx.allocator.building_blocks.region;
+public import stdx.allocator.building_blocks.stats_collector;
+public import stdx.allocator.gc_allocator;
+public import stdx.allocator.mallocator;
 
 // NOTE: this needs to be used instead of theAllocator due to Phobos issue 17564
 @property IAllocator vibeThreadAllocator()


### PR DESCRIPTION
As discussed before, `stdx-allocator` is a frozen version of std.experimental.allocator to avoid the frequent breakages. 

See also: https://github.com/dlang-community/discussions/issues/27