### PR TITLE
Use std.parallelism.totalCPUs instead of duplicating code

### DIFF
--- a/source/vibe/core/core.d
+++ b/source/vibe/core/core.d
@@ -602,35 +602,9 @@ public void setupWorkerThreads(uint num = logicalProcessorCount())
 */
 public @property uint logicalProcessorCount()
 {
-	version (linux) {
-		import core.sys.linux.sys.sysinfo;
-		return get_nprocs();
-	} else version (OSX) {
-		int count;
-		size_t count_len = count.sizeof;
-		sysctlbyname("hw.logicalcpu", &count, &count_len, null, 0);
-		return cast(uint)count_len;
-        } else version (FreeBSD) {
-                int count;
-                size_t count_len = count.sizeof;
-                sysctlbyname("hw.logicalcpu", &count, &count_len, null, 0);
-                return cast(uint)count_len;
-        } else version (NetBSD) {
-                int count;
-                size_t count_len = count.sizeof;
-                sysctlbyname("hw.logicalcpu", &count, &count_len, null, 0);
-                return cast(uint)count_len;
-	} else version (Windows) {
-		import core.sys.windows.windows;
-		SYSTEM_INFO sysinfo;
-		GetSystemInfo(&sysinfo);
-		return sysinfo.dwNumberOfProcessors;
-	} else static assert(false, "Unsupported OS!");
+        import std.parallelism : totalCPUs;
+        return totalCPUs;
 }
-version (OSX) private extern(C) int sysctlbyname(const(char)* name, void* oldp, size_t* oldlen, void* newp, size_t newlen);
-version (FreeBSD) private extern(C) int sysctlbyname(const(char)* name, void* oldp, size_t* oldlen, void* newp, size_t newlen);
-version (NetBSD) private extern(C) int sysctlbyname(const(char)* name, void* oldp, size_t* oldlen, void* newp, size_t newlen);
-version (linux) static if (__VERSION__ <= 2066) private extern(C) int get_nprocs();
 
 /**
 	Suspends the execution of the calling task to let other tasks and events be


### PR DESCRIPTION
This is the same as the vibe.d implementation.
BTW: This saves adding an implementation to support DragonFlyBSD (and other OS's in the future).