### PR TITLE
avoid Buffer type which creates a huge __initZ symbol

### DIFF
--- a/source/vibe/core/net.d
+++ b/source/vibe/core/net.d
@@ -658,10 +658,10 @@ mixin(tracer);
 		if (isInputStream!InputStream)
 	{
 		import std.algorithm.comparison : min;
+		import vibe.internal.allocator : theAllocator, makeArray, dispose;
 
-		static struct Buffer { ubyte[64*1024 - 4*size_t.sizeof] bytes = void; }
-		scope bufferobj = new Buffer; // FIXME: use heap allocation
-		auto buffer = bufferobj.bytes[];
+		scope buffer = () @trusted { return cast(ubyte[]) theAllocator.allocate(64*1024); }();
+		scope (exit) () @trusted { theAllocator.dispose(buffer); }();
 
 		//logTrace("default write %d bytes, empty=%s", nbytes, stream.empty);
 		if( nbytes == 0 ){

--- a/source/vibe/core/stream.d
+++ b/source/vibe/core/stream.d
@@ -39,12 +39,10 @@ ulong pipe(InputStream, OutputStream)(InputStream source, OutputStream sink, ulo
 	@blocking @trusted
 	if (isOutputStream!OutputStream && isInputStream!InputStream)
 {
-	import vibe.internal.allocator : theAllocator, make, dispose;
+	import vibe.internal.allocator : theAllocator, makeArray, dispose;
 
-	static struct Buffer { ubyte[64*1024] bytes = void; }
-	auto bufferobj = theAllocator.make!Buffer();
-	scope (exit) theAllocator.dispose(bufferobj);
-	auto buffer = bufferobj.bytes;
+	scope buffer = cast(ubyte[]) theAllocator.allocate(64*1024);
+	scope (exit) theAllocator.dispose(buffer);
 
 	//logTrace("default write %d bytes, empty=%s", nbytes, stream.empty);
 	ulong ret = 0;


### PR DESCRIPTION
- also see [15130 – dmd emits huge data for zero initialized struct](https://issues.dlang.org/show_bug.cgi?id=15130)