### PR TITLE
Fix incorrect return value in TCPConnection.leastSize()

### DIFF
--- a/source/vibe/core/net.d
+++ b/source/vibe/core/net.d
@@ -535,7 +535,7 @@ struct TCPConnection {
 		return s >= ConnectionState.connected && s < ConnectionState.activeClose;
 	}
 	@property bool empty() { return leastSize == 0; }
-	@property ulong leastSize() { waitForData(); return m_context && m_context.readBuffer.length; }
+	@property ulong leastSize() { waitForData(); return m_context ? m_context.readBuffer.length : 0; }
 	@property bool dataAvailableForRead() { return waitForData(0.seconds); }
 
 	void close()


### PR DESCRIPTION
Let the method return more than just 0 or 1