### PR TITLE
 Don't exit event loop prematurely.

### DIFF
--- a/source/vibe/core/core.d
+++ b/source/vibe/core/core.d
@@ -1140,8 +1140,8 @@ package(vibe) void performIdleProcessing()
 
 		if (again) {
 			auto er = eventDriver.core.processEvents(0.seconds);
-			if (er.among!(ExitReason.exited, ExitReason.outOfWaiters)) {
-				logDebug("Setting exit flag due to driver signalling exit");
+			if (er.among!(ExitReason.exited, ExitReason.outOfWaiters) && s_scheduler.scheduledTaskCount == 0) {
+				logDebug("Setting exit flag due to driver signalling exit: %s", er);
 				s_exitEventLoop = true;
 				return;
 			}

--- a/tests/issue-66-yield-eventloop-exit.d
+++ b/tests/issue-66-yield-eventloop-exit.d
@@ -1,0 +1,19 @@
+/+ dub.sdl:
+	name "tests"
+	dependency "vibe-core" path=".."
++/
+module tests;
+
+import vibe.core.core;
+
+void main()
+{
+	bool visited = false;
+	runTask({
+		yield();
+		visited = true;
+		exitEventLoop();
+	});
+	runApplication();
+	assert(visited);
+}


### PR DESCRIPTION
Idle processing needs to check whether there are still tasks scheduled to be resumed before setting the exit flag when there are no more waiters (I/O etc.). Fixes #66.