### PR TITLE
Ensure async lambdas are templates to fix LDC linker errors. Fixes #65.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,16 @@
 - Fixed a task scheduling assertion happening when worker tasks and timers were involved - [issue #58][issue58], [pull #60][issue60]
 - Fixed a race condition in `TaskPool` leading to random assertion failures - [7703cc6][commit7703cc6]
 - Fixed an issue where the event loop would exit prematurely when calling `yield` - [issue #66][issue66], [pull #67][issue67]
+- Fixed/worked around a linker error on LDC/macOS - [issue #65][issue65], [pull #68][issue68]
 
 [issue52]: https://github.com/vibe-d/vibe-core/issues/52
 [issue58]: https://github.com/vibe-d/vibe-core/issues/58
 [issue60]: https://github.com/vibe-d/vibe-core/issues/60
 [issue62]: https://github.com/vibe-d/vibe-core/issues/62
+[issue65]: https://github.com/vibe-d/vibe-core/issues/65
 [issue66]: https://github.com/vibe-d/vibe-core/issues/66
 [issue67]: https://github.com/vibe-d/vibe-core/issues/67
+[issue68]: https://github.com/vibe-d/vibe-core/issues/68
 [commit7703cc6]: https://github.com/vibe-d/vibe-core/commit/7703cc675f5ce56c1c8b4948e3f040453fd09791
 
 

--- a/source/vibe/core/core.d
+++ b/source/vibe/core/core.d
@@ -991,7 +991,7 @@ struct FileDescriptorEvent {
 		alias readwaiter = Waitable!(IOCallback,
 			cb => eventDriver.sockets.waitForData(m_socket, cb),
 			cb => eventDriver.sockets.cancelRead(m_socket),
-			(StreamSocketFD fd, IOStatus st, size_t nb) { got_data = st == IOStatus.ok; }
+			(fd, st, nb) { got_data = st == IOStatus.ok; }
 		);
 
 		asyncAwaitAny!(true, readwaiter)(timeout);

--- a/source/vibe/core/net.d
+++ b/source/vibe/core/net.d
@@ -201,7 +201,7 @@ TCPConnection connectTCP(NetworkAddress addr, NetworkAddress bind_address = anyA
 
 		alias waiter = Waitable!(ConnectCallback,
 			cb => eventDriver.sockets.connectStream(uaddr, baddr, cb),
-			(ConnectCallback cb, StreamSocketFD sock_fd) {
+			(cb, sock_fd) {
 				cancelled = true;
 				eventDriver.sockets.cancelConnectStream(sock_fd);
 			},
@@ -610,7 +610,7 @@ mixin(tracer);
 			determined or the specified timeout is reached.
 	*/
 	WaitForDataAsyncStatus waitForDataAsync(CALLABLE)(CALLABLE read_ready_callback, Duration timeout = Duration.max)
-		if (is(typeof(read_ready_callback(true))))
+		if (is(typeof(() @safe { read_ready_callback(true); } ())))
 	{
 mixin(tracer);
 		import vibe.core.core : setTimer;


### PR DESCRIPTION
If the lambda is a concrete function, two different versions will end up for it in the final binary on macOS when compiled with LDC. Using argument inference works around that issue.