### PR TITLE
Re-introduced setCommandLineArgs from vibe-d:core-0.8.2 (pull/1916)

### DIFF
--- a/source/vibe/core/args.d
+++ b/source/vibe/core/args.d
@@ -220,6 +220,31 @@ bool finalizeCommandLineOptions(string[]* args_out = null)
 */
 enum isOptionValue(T) = is(T == bool) || is(T : long) || is(T : double) || is(T == string);
 
+/**
+	This functions allows the usage of a custom command line argument parser
+	with vibe.d.
+
+	$(OL
+		$(LI build executable with version(VibeDisableCommandLineParsing))
+		$(LI parse main function arguments with a custom command line parser)
+		$(LI pass vibe.d arguments to `setCommandLineArgs`)
+		$(LI use vibe.d command line parsing utilities)
+	)
+
+	Params:
+		args = The arguments that should be handled by vibe.d
+*/
+void setCommandLineArgs(string[] args)
+{
+	g_args = args;
+}
+
+///
+unittest {
+	import std.format : format;
+	string[] args = ["--foo", "10"];
+	setCommandLineArgs(args);
+}
 
 private struct OptionInfo {
 	string[] names;


### PR DESCRIPTION
See https://github.com/vibe-d/vibe.d/pull/1916