### PR TITLE
Allow destructors to run in foreign threads. Fixes #69.

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -4,7 +4,7 @@ authors "Sönke Ludwig"
 copyright "Copyright © 2016-2018, rejectedsoftware e.K."
 license "MIT"
 
-dependency "eventcore" version="~>0.8.18"
+dependency "eventcore" version="~>0.8.32"
 dependency "stdx-allocator" version="~>2.77.0"
 
 targetName "vibe_core"

--- a/source/vibe/core/internal/release.d
+++ b/source/vibe/core/internal/release.d
@@ -1,0 +1,17 @@
+module vibe.core.internal.release;
+
+import eventcore.core;
+
+/// Release a handle in a thread-safe way
+void releaseHandle(string subsys, H)(H handle, shared(NativeEventDriver) drv)
+{
+	if (drv is (() @trusted => cast(shared)eventDriver)()) {
+		__traits(getMember, eventDriver, subsys).releaseRef(handle);
+	} else {
+		// in case the destructor was called from a foreign thread,
+		// perform the release in the owner thread
+		drv.core.runInOwnerThread((h) {
+			__traits(getMember, eventDriver, subsys).releaseRef(cast(H)h);
+		}, cast(size_t)handle);
+	}
+}

--- a/source/vibe/core/sync.d
+++ b/source/vibe/core/sync.d
@@ -1267,8 +1267,10 @@ private final class ThreadLocalWaiter(bool EVENT_TRIGGERED) {
 	static if (EVENT_TRIGGERED) {
 		~this()
 		{
+			import vibe.core.internal.release : releaseHandle;
+
 			if (m_event != EventID.invalid)
-				eventDriver.events.releaseRef(m_event);
+				releaseHandle!"events"(m_event, () @trusted { return cast(shared)m_driver; } ());
 		}
 	}
 


### PR DESCRIPTION
This change modifies destructors to anticipate that they can be called form a foreign thread if the GC is involved. The actual release of the reference will then happen deferred in the original thread.