### PR TITLE
Fix Task.running and Task.yield directly after runTask/yieldLock.

### DIFF
--- a/source/vibe/core/core.d
+++ b/source/vibe/core/core.d
@@ -395,6 +395,21 @@ package Task runTask_internal(alias TFI_SETUP)()
 	return handle;
 }
 
+unittest { // ensure task.running is true directly after runTask
+	Task t;
+	bool hit = false;
+	{
+		auto l = yieldLock();
+		t = runTask({ hit = true; });
+		assert(!hit);
+		assert(t.running);
+	}
+	t.join();
+	assert(!t.running);
+	assert(hit);
+}
+
+
 /**
 	Runs a new asynchronous task in a worker thread.
 


### PR DESCRIPTION
The status of the task was erroneously reported as not running until the task was actually executed for the first time (which only happens after the yield lock has been lifted).