### PR TITLE
Fix logger colours to make it look good on terminals with black and white background

### DIFF
--- a/source/vibe/core/log.d
+++ b/source/vibe/core/log.d
@@ -295,9 +295,9 @@ final class FileLogger : Logger {
 				final switch (msg.level) {
 					case LogLevel.trace: dst.put("\x1b[49;38;5;243m"); break;
 					case LogLevel.debugV: dst.put("\x1b[49;38;5;245m"); break;
-					case LogLevel.debug_: dst.put("\x1b[49;38;5;248m"); break;
-					case LogLevel.diagnostic: dst.put("\x1b[49;38;5;253m"); break;
-					case LogLevel.info: dst.put("\x1b[49;38;5;15m"); break;
+					case LogLevel.debug_: dst.put("\x1b[49;38;5;180m"); break;
+					case LogLevel.diagnostic: dst.put("\x1b[49;38;5;143m"); break;
+					case LogLevel.info: dst.put("\x1b[49;38;5;29m"); break;
 					case LogLevel.warn: dst.put("\x1b[49;38;5;220m"); break;
 					case LogLevel.error: dst.put("\x1b[49;38;5;9m"); break;
 					case LogLevel.critical: dst.put("\x1b[41;38;5;15m"); break;


### PR DESCRIPTION
There's one problem with current colour pallette of the default logger - it's impossible to read its messages when using terminal with white background.

I managed to find only one issue about this (vibe-d/vibe.d#2019).

## Before
![black_on_white original](https://user-images.githubusercontent.com/27865436/41192457-30021faa-6bfe-11e8-9ad3-bc88cd7eb12e.png)
![white_on_black original](https://user-images.githubusercontent.com/27865436/41192458-3022203e-6bfe-11e8-81cb-4fca17f233a2.png)

## After
![black_on_white new](https://user-images.githubusercontent.com/27865436/41192464-444ee826-6bfe-11e8-8691-43b0dc8785f4.png)
![white_on_black new](https://user-images.githubusercontent.com/27865436/41192465-4478cb32-6bfe-11e8-9a23-3c8c63390568.png)
