### PR TITLE
Revert "Mark the Path(Segment) constructor as nothrow."

### DIFF
--- a/source/vibe/core/path.d
+++ b/source/vibe/core/path.d
@@ -384,7 +384,7 @@ struct GenericPath(F) {
 		single-element range.
 	*/
 	this(Segment segment)
-	nothrow {
+	{
 		import std.range : only;
 		this(only(segment));
 	}


### PR DESCRIPTION
This reverts commit 5f18693c49a0c0a7359bb32fefd5f8719950a573.

See: https://github.com/vibe-d/vibe.d/issues/2184

Could we merge get this merged ASAP and get a new patch release out?
Thanks!