### PR TITLE
Fix possible infinite loop in TaskScheduler.process.

### DIFF
--- a/source/vibe/core/task.d
+++ b/source/vibe/core/task.d
@@ -962,7 +962,27 @@ private struct TaskFiberQueue {
 		task.m_queue = null;
 		task.m_prev = null;
 		task.m_next = null;
+		length--;
 	}
+}
+
+unittest {
+	auto f1 = new TaskFiber;
+	auto f2 = new TaskFiber;
+
+	TaskFiberQueue q;
+	assert(q.empty && q.length == 0);
+	q.insertFront(f1);
+	assert(!q.empty && q.length == 1);
+	q.insertFront(f2);
+	assert(!q.empty && q.length == 2);
+	q.popFront();
+	assert(!q.empty && q.length == 1);
+	q.popFront();
+	assert(q.empty && q.length == 0);
+	q.insertFront(f1);
+	q.remove(f1);
+	assert(q.empty && q.length == 0);
 }
 
 private struct FLSInfo {


### PR DESCRIPTION
Fixes a discrepancy in TaskFiberQueue between empty and length, which causes process() to never return, thus processing events without timeout indefinitely.