### PR TITLE
Implement callback based timers without relying on a task. Fixes #86.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,14 @@
 - Simplified worker task logic by avoiding an explicit event loop - [pull #95][issue95]
 - Fixed an issue in `WindowsPath`, where an empty path was converted to "/" when cast to another path type - [pull #91][issue91]
 - Fixed two hang issues in `TaskPool` causing the worker task processing to possibly hang at shutdown or to temporarily hang during run time - [pull #96][issue96]
+- Fixed internal timer callback tasks leaking memory - [issue #86][issue86], [pull #98][issue98]
 
 [issue91]: https://github.com/vibe-d/vibe-core/issues/91
 [issue92]: https://github.com/vibe-d/vibe-core/issues/92
 [issue95]: https://github.com/vibe-d/vibe-core/issues/95
 [issue96]: https://github.com/vibe-d/vibe-core/issues/96
 [issue97]: https://github.com/vibe-d/vibe-core/issues/97
+[issue98]: https://github.com/vibe-d/vibe-core/issues/98
 
 
 1.4.3 - 2018-09-03

--- a/dub.sdl
+++ b/dub.sdl
@@ -4,7 +4,7 @@ authors "Sönke Ludwig"
 copyright "Copyright © 2016-2018, rejectedsoftware e.K."
 license "MIT"
 
-dependency "eventcore" version="~>0.8.32"
+dependency "eventcore" version="~>0.8.39"
 dependency "stdx-allocator" version="~>2.77.0"
 
 targetName "vibe_core"


### PR DESCRIPTION
In the previous implementation, the callback tasks were starving as soon as the last external reference to a non-pending timer was given up.