### PR TITLE
Fix assertion in SpinLock when called from a signal handler.

### DIFF
--- a/source/vibe/core/core.d
+++ b/source/vibe/core/core.d
@@ -1350,9 +1350,6 @@ shared static this()
 
 	import std.concurrency;
 	scheduler = new VibedScheduler;
-
-	import vibe.core.sync : SpinLock;
-	SpinLock.setup();
 }
 
 shared static ~this()
@@ -1377,10 +1374,6 @@ static this()
 	synchronized (st_threadsMutex)
 		if (!st_threads.any!(c => c.thread is thisthr))
 			st_threads ~= ThreadContext(thisthr);
-
-
-	import vibe.core.sync : SpinLock;
-	SpinLock.setup();
 }
 
 static ~this()
@@ -1463,7 +1456,10 @@ private extern(C) void onSignal(int signal)
 nothrow {
 	logInfo("Received signal %d. Shutting down.", signal);
 	atomicStore(st_term, true);
-	try st_threadsSignal.emit(); catch (Throwable) {}
+	try st_threadsSignal.emit();
+	catch (Throwable th) {
+		logDebug("Failed to notify for event loop exit: %s", th.msg);
+	}
 }
 
 private extern(C) void onBrokenPipe(int signal)


### PR DESCRIPTION
Since the signal handler can be called in any thread of the application, it may happen so in a non-D thread where Thread.getThis() returns null. This change works around this and also removes the need to call SpinLock.setup on thread startup.