### PR TITLE
fix relying on implicit const conversion of JSONValue

### DIFF
--- a/source/vibe/core/args.d
+++ b/source/vibe/core/args.d
@@ -298,7 +298,7 @@ private void init()
 	readOption("h|help", &g_help, "Prints this help screen.");
 }
 
-private T fromValue(T)(JSONValue val)
+private T fromValue(T)(in JSONValue val)
 {
 	import std.conv : to;
 	static if (is(T == bool)) return val.type == JSON_TYPE.TRUE;


### PR DESCRIPTION
- "key" in JSONValue returns const(JSONValue)*
- fromValue expected non-const JSONValue
- implicit conversion of const(JSONValue) to JSONValue to be fixed
  with https://github.com/dlang/phobos/pull/6716