### PR TITLE
Make waitForData not assert fail on close fix #110

### DIFF
--- a/source/vibe/core/net.d
+++ b/source/vibe/core/net.d
@@ -569,7 +569,13 @@ mixin(tracer);
 		alias waiter = Waitable!(IOCallback,
 			cb => eventDriver.sockets.read(m_socket, m_context.readBuffer.peekDst(), mode, cb),
 			(cb) { cancelled = true; eventDriver.sockets.cancelRead(m_socket); },
-			(sock, st, nb) { assert(sock == m_socket); status = st; nbytes = nb; }
+			(sock, st, nb) {
+				if (m_socket == StreamSocketFD.invalid) {
+					cancelled = true;
+					return;
+				}
+				assert(sock == m_socket); status = st; nbytes = nb;
+			}
 		);
 
 		asyncAwaitAny!(true, waiter)(timeout);

--- a/source/vibe/core/net.d
+++ b/source/vibe/core/net.d
@@ -580,7 +580,7 @@ mixin(tracer);
 
 		asyncAwaitAny!(true, waiter)(timeout);
 
-		if (cancelled) return false;
+		if (cancelled || !m_context) return false;
 
 		logTrace("Socket %s, read %s bytes: %s", m_socket, nbytes, status);
 

--- a/tests/issue-110-close-while-waitForData.d
+++ b/tests/issue-110-close-while-waitForData.d
@@ -1,0 +1,39 @@
+/+ dub.sdl:
+	name "test"
+	dependency "vibe-core" path=".."
++/
+module test;
+
+import core.time;
+
+import vibe.core.core;
+import vibe.core.net;
+
+ushort port;
+void main()
+{
+	runTask(&server);
+	runTask(&client);
+
+	runEventLoop();
+}
+
+void server()
+{
+	auto listener = listenTCP(0, (conn) @safe nothrow {
+		try { sleep(200.msecs); } catch (Exception) {}
+	});
+	port = listener[0].bindAddress.port;
+}
+
+void client()
+{
+	sleep(100.msecs);
+	auto tcp = connectTCP("127.0.0.1", port);
+	runTask({
+		sleep(10.msecs);
+		tcp.close();
+	});
+	assert(!tcp.waitForData());
+	exitEventLoop(true);
+}


### PR DESCRIPTION
when m_socket is StreamSocketFD.invalid (which only is set when constructed or when closing) then treat the waitForData result as cancelled.

fix #110