### PR TITLE
release ref on failing connectTCP

### DIFF
--- a/source/vibe/core/net.d
+++ b/source/vibe/core/net.d
@@ -218,8 +218,10 @@ TCPConnection connectTCP(NetworkAddress addr, NetworkAddress bind_address = anyA
 			": timeout");
 
 		if (status != ConnectStatus.connected) {
-			if (sock != SocketFD.invalid)
-				assert(!eventDriver.sockets.releaseRef(sock));
+			if (sock != SocketFD.invalid) {
+				bool refsLeft = eventDriver.sockets.releaseRef(sock);
+				assert(!refsLeft);
+			}
 
 			enforce(false, "Failed to connect to "~addr.toString()~": "~status.to!string);
 			assert(false);

--- a/source/vibe/core/net.d
+++ b/source/vibe/core/net.d
@@ -216,7 +216,14 @@ TCPConnection connectTCP(NetworkAddress addr, NetworkAddress bind_address = anyA
 
 		enforce(!cancelled, "Failed to connect to " ~ addr.toString() ~
 			": timeout");
-		enforce(status == ConnectStatus.connected, "Failed to connect to "~addr.toString()~": "~status.to!string);
+
+		if (status != ConnectStatus.connected) {
+			if (sock != SocketFD.invalid)
+				assert(!eventDriver.sockets.releaseRef(sock));
+
+			enforce(false, "Failed to connect to "~addr.toString()~": "~status.to!string);
+			assert(false);
+		}
 
 		return TCPConnection(sock, uaddr);
 	} ();

--- a/tests/issue-115-connect-fail-leak.d
+++ b/tests/issue-115-connect-fail-leak.d
@@ -1,0 +1,22 @@
+/+ dub.sdl:
+	name "test"
+	dependency "vibe-core" path=".."
++/
+module test;
+
+import vibe.core.core;
+import vibe.core.log;
+import vibe.core.net;
+
+void main()
+{
+	foreach (_; 0 .. 20) {
+		TCPConnection conn;
+		try {
+			conn = connectTCP("127.0.0.1", 16565);
+			logError("Connection: %s", conn);
+			conn.close();
+			assert(false, "Didn't expect TCP connection on port 16565 to succeed");
+		} catch (Exception) { }
+	}
+}


### PR DESCRIPTION
fix #115 

Unsure how this affects windows, ~~but if the auto tests are also run on windows it should find any issue there.~~ please test manually

status is refused in this case and it's not handled by the existing cases cancelling a connection, so the reference to the socket still exists and needs to be released by the caller here.