### PR TITLE
remove refsLeft assert

### DIFF
--- a/source/vibe/core/net.d
+++ b/source/vibe/core/net.d
@@ -217,10 +217,8 @@ TCPConnection connectTCP(NetworkAddress addr, NetworkAddress bind_address = anyA
 			": timeout");
 
 		if (status != ConnectStatus.connected) {
-			if (sock != SocketFD.invalid) {
-				bool refsLeft = eventDriver.sockets.releaseRef(sock);
-				assert(!refsLeft);
-			}
+			if (sock != SocketFD.invalid)
+				eventDriver.sockets.releaseRef(sock);
 
 			enforce(false, "Failed to connect to "~addr.toString()~": "~status.to!string);
 			assert(false);


### PR DESCRIPTION
It seems when running in a vibe-d app listening to HTTP requests that the assert fails. Even though I would like there to be a check, closing the vibe.d app afterwards shows no leaked handles so I think it's fine, and definitely better than not starting anymore at all.