### PR TITLE
Fix runApplication handling of unrecognized command-line args

### DIFF
--- a/source/vibe/core/core.d
+++ b/source/vibe/core/core.d
@@ -90,7 +90,7 @@ version (Windows)
 */
 int runApplication(string[]* args_out = null)
 @safe {
-	try if (!() @trusted { return finalizeCommandLineOptions(); } () ) return 0;
+	try if (!() @trusted { return finalizeCommandLineOptions(args_out); } () ) return 0;
 	catch (Exception e) {
 		logDiagnostic("Error processing command line: %s", e.msg);
 		return 1;


### PR DESCRIPTION
`runApplication` takes an `args_out` parameter which, if non-null, is supposed to be set to match unrecognized command-line args.  However, the parameter is never passed to `finalizeCommandLineOptions`, which will therefore log an error and throw an exception if any command line arguments are unrecognized.

This patch fixes the oversight, ensuring that `runApplication` will correctly populate a non-null `args_out` parameter with unrecognized command-line arguments, and not throw an exception in this case.