### PR TITLE
support isFile

### DIFF
--- a/source/vibe/core/file.d
+++ b/source/vibe/core/file.d
@@ -385,6 +385,9 @@ struct FileInfo {
 	/// True if this is a directory or a symlink pointing to a directory
 	bool isDirectory;
 
+	/// True if this is a file. On POSIX if both isFile and isDirectory are false it is a special file.
+	bool isFile;
+
 	/** True if the file's hidden attribute is set.
 
 		On systems that don't support a hidden attribute, any file starting with
@@ -737,6 +740,7 @@ private FileInfo makeFileInfo(DirEntry ent)
 	else ret.timeCreated = ent.timeLastModified;
 	ret.isSymlink = ent.isSymlink;
 	ret.isDirectory = ent.isDir;
+	ret.isFile = ent.isFile;
 	version (Windows) {
 		import core.sys.windows.windows : FILE_ATTRIBUTE_HIDDEN;
 		ret.hidden = (ent.attributes & FILE_ATTRIBUTE_HIDDEN) != 0;


### PR DESCRIPTION
Needed on POSIX systems to recognize special files (isFile and isDir are both false in this case). Same API as std.file.

edit: references https://github.com/vibe-d/vibe-core/issues/132