### PR TITLE
Use timeout with `leastSize` on TCPConnection

### DIFF
--- a/source/vibe/core/net.d
+++ b/source/vibe/core/net.d
@@ -593,7 +593,7 @@ mixin(tracer);
 			}
 		);
 
-		asyncAwaitAny!(true, waiter)(timeout);
+		enforce!ReadTimeoutException(asyncAwaitAny!(true, waiter)(timeout), "Read operation timed out");
 
 		if (cancelled || !m_context) return false;
 

--- a/source/vibe/core/net.d
+++ b/source/vibe/core/net.d
@@ -553,7 +553,10 @@ struct TCPConnection {
 		return s >= ConnectionState.connected && s < ConnectionState.activeClose;
 	}
 	@property bool empty() { return leastSize == 0; }
-	@property ulong leastSize() { waitForData(); return m_context ? m_context.readBuffer.length : 0; }
+	@property ulong leastSize() {
+		if (m_context) waitForData(m_context.readTimeout);
+		return m_context ? m_context.readBuffer.length : 0;
+	}
 	@property bool dataAvailableForRead() { return waitForData(0.seconds); }
 
 	void close()


### PR DESCRIPTION
I'm not exactly sure about this, but I guess that if one sets the read timeout on the `TCPConnection` it should be used in this blocking call too so it won't block forever.