### PR TITLE
Handle terminated eventcore drivers gracefully when releasing handles.

### DIFF
--- a/source/vibe/core/internal/release.d
+++ b/source/vibe/core/internal/release.d
@@ -8,6 +8,15 @@ void releaseHandle(string subsys, H)(H handle, shared(NativeEventDriver) drv)
 	if (drv is (() @trusted => cast(shared)eventDriver)()) {
 		__traits(getMember, eventDriver, subsys).releaseRef(handle);
 	} else {
+		// if the owner driver has already been disposed, there is nothing we
+		// can do anymore
+		if (!drv.core) {
+			import vibe.core.log : logWarn;
+			logWarn("Leaking %s handle %s, because owner thread/driver has already terminated",
+				H.name, handle.value);
+			return;
+		}
+
 		// in case the destructor was called from a foreign thread,
 		// perform the release in the owner thread
 		drv.core.runInOwnerThread((h) {


### PR DESCRIPTION
Instead of crashing, this now prints a warning message. See #135.