### PR TITLE
Clean up std.json deprecation, remove DUB hack in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,7 @@ branches:
     - master
 
 before_install:
-  # Use the dub-updating fork of the installer script until https://github.com/dlang/installer/pull/301 is merged
-  - wget https://raw.githubusercontent.com/wilzbach/installer-dub/master/script/install.sh -O ~/dlang/install.dub.sh
+  - wget https://dlang.org/install.sh -O ~/dlang/install.dub.sh
   - . $(bash ~/dlang/install.dub.sh -a dub)
   - dub --version
 

--- a/source/vibe/core/args.d
+++ b/source/vibe/core/args.d
@@ -301,7 +301,13 @@ private void init()
 private T fromValue(T)(in JSONValue val)
 {
 	import std.conv : to;
-	static if (is(T == bool)) return val.type == JSON_TYPE.TRUE;
+	static if (is(T == bool)) {
+        // JSONType.TRUE has been deprecated in v2.087.0
+        static if (is(typeof(JSONType.true_)))
+            return val.type == JSONType.true_;
+        else
+            return val.type == JSONType.TRUE;
+    }
 	else static if (is(T : long)) return val.integer.to!T;
 	else static if (is(T : double)) return val.floating.to!T;
 	else static if (is(T == string)) return val.str;

--- a/source/vibe/core/args.d
+++ b/source/vibe/core/args.d
@@ -306,7 +306,7 @@ private T fromValue(T)(in JSONValue val)
         static if (is(typeof(JSONType.true_)))
             return val.type == JSONType.true_;
         else
-            return val.type == JSONType.TRUE;
+            return val.type == JSON_TYPE.TRUE;
     }
 	else static if (is(T : long)) return val.integer.to!T;
 	else static if (is(T : double)) return val.floating.to!T;


### PR DESCRIPTION
CC @s-ludwig : I was thinking of doing the same to Vibe.d, as the CI nowadays takes half a day for a single PR.