### PR TITLE
Avoid all blocking file operations outside of worker threads

### DIFF
--- a/source/vibe/core/concurrency.d
+++ b/source/vibe/core/concurrency.d
@@ -1083,7 +1083,9 @@ struct Future(T) {
 	import vibe.internal.freelistref : FreeListRef;
 
 	private {
-		FreeListRef!(shared(T)) m_result;
+		alias ResultRef = FreeListRef!(shared(Tuple!(T, string)));
+
+		ResultRef m_result;
 		Task m_task;
 	}
 
@@ -1102,15 +1104,18 @@ struct Future(T) {
 		if (!ready) m_task.join();
 		assert(ready, "Task still running after join()!?");
 
+		if (m_result.get[1].length)
+			throw new Exception(m_result.get[1]);
+
 		// casting away shared is safe, because this is a unique reference
-		return *() @trusted { return cast(T*)&m_result.get(); } ();
+		return *() @trusted { return cast(T*)&m_result.get()[0]; } ();
 	}
 
 	alias getResult this;
 
 	private void init()
-	{
-		m_result = FreeListRef!(shared(T))();
+	@safe {
+		m_result = ResultRef();
 	}
 }
 
@@ -1143,8 +1148,9 @@ Future!(ReturnType!CALLABLE) async(CALLABLE, ARGS...)(CALLABLE callable, ARGS ar
 	alias RET = ReturnType!CALLABLE;
 	Future!RET ret;
 	ret.init();
-	static void compute(FreeListRef!(shared(RET)) dst, CALLABLE callable, ARGS args) {
-		dst.get = cast(shared(RET))callable(args);
+	static void compute(Future!RET.ResultRef dst, CALLABLE callable, ARGS args) {
+		try dst.get[0] = cast(shared(RET))callable(args);
+		catch (Exception e) dst.get[1] = e.msg.length ? e.msg : "Asynchronous operation failed";
 	}
 	static if (isWeaklyIsolated!CALLABLE && isWeaklyIsolated!ARGS) {
 		ret.m_task = runWorkerTaskH(&compute, ret.m_result, callable, args);
@@ -1199,6 +1205,26 @@ unittest {
 		assert(async(&sum2, 2, 3).getResult() == 5);
 	}
 }
+
+Future!(ReturnType!CALLABLE) asyncWork(CALLABLE, ARGS...)(CALLABLE callable, ARGS args) @safe
+	if (is(typeof(callable(args)) == ReturnType!CALLABLE) &&
+		isWeaklyIsolated!CALLABLE && isWeaklyIsolated!ARGS)
+{
+	import vibe.core.core;
+	import vibe.internal.freelistref : FreeListRef;
+	import std.functional : toDelegate;
+
+	alias RET = ReturnType!CALLABLE;
+	Future!RET ret;
+	ret.init();
+	static void compute(Future!RET.ResultRef dst, CALLABLE callable, ARGS args) {
+		try *cast(RET*)&dst.get[0] = callable(args);
+		catch (Exception e) dst.get[1] = e.msg.length ? e.msg : "Asynchronous operation failed";
+	}
+	ret.m_task = runWorkerTaskH(&compute, ret.m_result, callable, args);
+	return ret;
+}
+
 
 /******************************************************************************/
 /* std.concurrency compatible interface for message passing                   */

--- a/source/vibe/core/concurrency.d
+++ b/source/vibe/core/concurrency.d
@@ -1088,7 +1088,7 @@ struct Future(T) {
 	}
 
 	/// Checks if the values was fully computed.
-	@property bool ready() const { return !m_task.running; }
+	@property bool ready() const @safe { return !m_task.running; }
 
 	/** Returns the computed value.
 
@@ -1098,10 +1098,12 @@ struct Future(T) {
 		instead.
 	*/
 	ref T getResult()
-	{
+	@safe {
 		if (!ready) m_task.join();
 		assert(ready, "Task still running after join()!?");
-		return *cast(T*)&m_result.get(); // casting away shared is safe, because this is a unique reference
+
+		// casting away shared is safe, because this is a unique reference
+		return *() @trusted { return cast(T*)&m_result.get(); } ();
 	}
 
 	alias getResult this;
@@ -1153,7 +1155,7 @@ Future!(ReturnType!CALLABLE) async(CALLABLE, ARGS...)(CALLABLE callable, ARGS ar
 }
 
 ///
-unittest {
+@safe unittest {
 	import vibe.core.core;
 	import vibe.core.log;
 

--- a/source/vibe/core/core.d
+++ b/source/vibe/core/core.d
@@ -614,15 +614,17 @@ void runWorkerTaskDistH(HCB, FT, ARGS...)(scope HCB on_handle, FT func, auto ref
 	See_also: `runWorkerTask`, `runWorkerTaskH`, `runWorkerTaskDist`
 */
 public void setupWorkerThreads(uint num = logicalProcessorCount())
-{
+@safe {
 	static bool s_workerThreadsStarted = false;
 	if (s_workerThreadsStarted) return;
 	s_workerThreadsStarted = true;
 
-	synchronized (st_threadsMutex) {
-		if (!st_workerPool)
-			st_workerPool = new shared TaskPool(num);
-	}
+	() @trusted {
+		synchronized (st_threadsMutex) {
+			if (!st_workerPool)
+				st_workerPool = new shared TaskPool(num);
+		}
+	} ();
 }
 
 


### PR DESCRIPTION
There are currently some file operations (existsFile, getFileInfo, listDirectory) that are directly implemented using the blocking standard library functionality. To avoid stalling the event loop, these are now run in worker tasks.

As a preparatory step, some concurrency functions have been fixed to be `@safe`.