### PR TITLE
Correct copyright holder.

### DIFF
--- a/source/vibe/appmain.d
+++ b/source/vibe/appmain.d
@@ -14,7 +14,7 @@
 	calls to vibe.core.args.finalizeCommandLineOptions and vibe.core.core.lowerPrivileges to get the
 	same behavior.
 
-	Copyright: © 2012-2016 RejectedSoftware e.K.
+	Copyright: © 2012-2016 Sönke Ludwig
 	License: Subject to the terms of the MIT license, as written in the included LICENSE.txt file.
 	Authors: Sönke Ludwig
 */

--- a/source/vibe/core/args.d
+++ b/source/vibe/core/args.d
@@ -7,7 +7,7 @@
 	to their values. It is searched for in the local directory, user's home
 	directory, or /etc/vibe/ (POSIX only), whichever is found first.
 
-	Copyright: © 2012-2016 RejectedSoftware e.K.
+	Copyright: © 2012-2016 Sönke Ludwig
 	License: Subject to the terms of the MIT license, as written in the included LICENSE.txt file.
 	Authors: Sönke Ludwig, Vladimir Panteleev
 */

--- a/source/vibe/core/channel.d
+++ b/source/vibe/core/channel.d
@@ -1,6 +1,6 @@
 /** Implements a thread-safe, typed producer-consumer queue.
 
-	Copyright: © 2017-2019 RejectedSoftware e.K.
+	Copyright: © 2017-2019 Sönke Ludwig
 	Authors: Sönke Ludwig
 	License: Subject to the terms of the MIT license, as written in the included LICENSE.txt file.
 */

--- a/source/vibe/core/concurrency.d
+++ b/source/vibe/core/concurrency.d
@@ -4,7 +4,7 @@
 	This module is modeled after std.concurrency, but provides a fiber-aware alternative
 	to it. All blocking operations will yield the calling fiber instead of blocking it.
 
-	Copyright: © 2013-2014 RejectedSoftware e.K.
+	Copyright: © 2013-2014 Sönke Ludwig
 	License: Subject to the terms of the MIT license, as written in the included LICENSE.txt file.
 	Authors: Sönke Ludwig
 */

--- a/source/vibe/core/connectionpool.d
+++ b/source/vibe/core/connectionpool.d
@@ -1,7 +1,7 @@
 /**
 	Generic connection pool for reusing persistent connections across fibers.
 
-	Copyright: © 2012-2016 RejectedSoftware e.K.
+	Copyright: © 2012-2016 Sönke Ludwig
 	License: Subject to the terms of the MIT license, as written in the included LICENSE.txt file.
 	Authors: Sönke Ludwig
 */

--- a/source/vibe/core/core.d
+++ b/source/vibe/core/core.d
@@ -1,7 +1,7 @@
 /**
 	This module contains the core functionality of the vibe.d framework.
 
-	Copyright: © 2012-2019 RejectedSoftware e.K.
+	Copyright: © 2012-2019 Sönke Ludwig
 	License: Subject to the terms of the MIT license, as written in the included LICENSE.txt file.
 	Authors: Sönke Ludwig
 */

--- a/source/vibe/core/file.d
+++ b/source/vibe/core/file.d
@@ -1,7 +1,7 @@
 /**
 	File handling functions and types.
 
-	Copyright: © 2012-2019 RejectedSoftware e.K.
+	Copyright: © 2012-2019 Sönke Ludwig
 	License: Subject to the terms of the MIT license, as written in the included LICENSE.txt file.
 	Authors: Sönke Ludwig
 */

--- a/source/vibe/core/log.d
+++ b/source/vibe/core/log.d
@@ -1,7 +1,7 @@
 /**
 	Central logging facility for vibe.
 
-	Copyright: © 2012-2014 RejectedSoftware e.K.
+	Copyright: © 2012-2014 Sönke Ludwig
 	License: Subject to the terms of the MIT license, as written in the included LICENSE.txt file.
 	Authors: Sönke Ludwig
 */

--- a/source/vibe/core/net.d
+++ b/source/vibe/core/net.d
@@ -1,7 +1,7 @@
 /**
 	TCP/UDP connection and server handling.
 
-	Copyright: © 2012-2016 RejectedSoftware e.K.
+	Copyright: © 2012-2016 Sönke Ludwig
 	Authors: Sönke Ludwig
 	License: Subject to the terms of the MIT license, as written in the included LICENSE.txt file.
 */

--- a/source/vibe/core/stream.d
+++ b/source/vibe/core/stream.d
@@ -10,7 +10,7 @@
 	using the appropriate trait (e.g. `isInputStream`) instead of assuming the specific interface
 	type (e.g. `InputStream`).
 
-	Copyright: © 2012-2016 RejectedSoftware e.K.
+	Copyright: © 2012-2016 Sönke Ludwig
 	License: Subject to the terms of the MIT license, as written in the included LICENSE.txt file.
 	Authors: Sönke Ludwig
 */

--- a/source/vibe/core/task.d
+++ b/source/vibe/core/task.d
@@ -1,7 +1,7 @@
 /**
 	Contains interfaces and enums for evented I/O drivers.
 
-	Copyright: © 2012-2016 RejectedSoftware e.K.
+	Copyright: © 2012-2016 Sönke Ludwig
 	Authors: Sönke Ludwig
 	License: Subject to the terms of the MIT license, as written in the included LICENSE.txt file.
 */

--- a/source/vibe/core/taskpool.d
+++ b/source/vibe/core/taskpool.d
@@ -1,7 +1,7 @@
 /**
 	Multi-threaded task pool implementation.
 
-	Copyright: © 2012-2017 RejectedSoftware e.K.
+	Copyright: © 2012-2017 Sönke Ludwig
 	License: Subject to the terms of the MIT license, as written in the included LICENSE.txt file.
 	Authors: Sönke Ludwig
 */

--- a/source/vibe/internal/array.d
+++ b/source/vibe/internal/array.d
@@ -1,7 +1,7 @@
 /**
 	Utility functions for array processing
 
-	Copyright: © 2012 RejectedSoftware e.K.
+	Copyright: © 2012 Sönke Ludwig
 	License: Subject to the terms of the MIT license, as written in the included LICENSE.txt file.
 	Authors: Sönke Ludwig
 */

--- a/source/vibe/internal/freelistref.d
+++ b/source/vibe/internal/freelistref.d
@@ -4,7 +4,7 @@
 	Note that this module currently is a big sand box for testing allocation related stuff.
 	Nothing here, including the interfaces, is final but rather a lot of experimentation.
 
-	Copyright: © 2012-2013 RejectedSoftware e.K.
+	Copyright: © 2012-2013 Sönke Ludwig
 	License: Subject to the terms of the MIT license, as written in the included LICENSE.txt file.
 	Authors: Sönke Ludwig
 */

--- a/source/vibe/internal/hashmap.d
+++ b/source/vibe/internal/hashmap.d
@@ -1,7 +1,7 @@
 /**
 	Internal hash map implementation.
 
-	Copyright: © 2013 RejectedSoftware e.K.
+	Copyright: © 2013 Sönke Ludwig
 	License: Subject to the terms of the MIT license, as written in the included LICENSE.txt file.
 	Authors: Sönke Ludwig
 */

--- a/source/vibe/internal/string.d
+++ b/source/vibe/internal/string.d
@@ -1,7 +1,7 @@
 /**
 	Utility functions for string processing
 
-	Copyright: © 2012-2014 RejectedSoftware e.K.
+	Copyright: © 2012-2014 Sönke Ludwig
 	License: Subject to the terms of the MIT license, as written in the included LICENSE.txt file.
 	Authors: Sönke Ludwig
 */

--- a/source/vibe/internal/traits.d
+++ b/source/vibe/internal/traits.d
@@ -2,7 +2,7 @@
 	Extensions to `std.traits` module of Phobos. Some may eventually make it into Phobos,
 	some are dirty hacks that work only for vibe.d
 
-	Copyright: © 2012 RejectedSoftware e.K.
+	Copyright: © 2012 Sönke Ludwig
 	License: Subject to the terms of the MIT license, as written in the included LICENSE.txt file.
 	Authors: Sönke Ludwig, Михаил Страшун
 */

--- a/source/vibe/internal/typetuple.d
+++ b/source/vibe/internal/typetuple.d
@@ -1,7 +1,7 @@
 /**
 	Additions to std.typetuple pending for inclusion into Phobos.
 
-	Copyright: © 2013 RejectedSoftware e.K.
+	Copyright: © 2013 Sönke Ludwig
 	License: Subject to the terms of the MIT license, as written in the included LICENSE.txt file.
 	Authors: Михаил Страшун
 */


### PR DESCRIPTION
rejectedsoftware e.K. doesn't exist anymore since mid-2019.