### PR TITLE
Update list of supported compilers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,5 @@ before_install:
 
 script: ./travis-ci.sh
 
-sudo: false
-
 after_success:
  - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,6 @@ d:
   - ldc-1.17.0
   - ldc-1.16.0
   - ldc-1.15.0
-  - ldc-1.14.0
-  - ldc-1.9.0
   - dmd-2.087.1
   - dmd-2.086.1
   - dmd-2.085.1
@@ -44,10 +42,6 @@ matrix:
       - d: ldc-1.16.0
         os: osx
       - d: ldc-1.15.0
-        os: osx
-      - d: ldc-1.14.0
-        os: osx
-      - d: ldc-1.9.0
         os: osx
   include:
     - d: dmd

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,16 @@ d:
   # this way the overall test time gets cut down (GDC/LDC are a lot
   # slower tham DMD, so they should be started early), while still
   # catching most DMD version related build failures early
-  - dmd-2.088.0
+  - dmd-2.091.0
   - dmd-2.078.3
-  - ldc-1.17.0
-  - ldc-1.16.0
+  - ldc-1.20.1
   - ldc-1.15.0
-  - dmd-2.087.1
-  - dmd-2.086.1
-  - dmd-2.085.1
-  - dmd-2.079.0
-  - dmd-beta
+  - ldc-1.19.0
+  - ldc-1.18.0
+  - dmd-2.089.1
+  - dmd-2.088.1
+  - dmd-nightly
+  - ldc-latest-ci
 
 env:
     - CONFIG=select
@@ -30,16 +30,15 @@ env:
 matrix:
   allow_failures:
     - env: CONFIG=libasync
-    - d: dmd-beta
+    - d: dmd-nightly
+    - d: ldc-latest-ci
   exclude:
       - os: linux
         env: CONFIG=kqueue
       - os: osx
         env: CONFIG=epoll
       # see https://github.com/ldc-developers/ldc/issues/2187
-      - d: ldc-1.17.0
-        os: osx
-      - d: ldc-1.16.0
+      - d: ldc-1.18.0
         os: osx
       - d: ldc-1.15.0
         os: osx


### PR DESCRIPTION
Since LDC v1.9.0 and v1.14.0 are consistently failing, remove them from the CI.
It's not my preferred solution to remove a failing test, but no one seems interested in fixing this (master has been red for over 2 months), and it seems to be an LDC specific issue (so not a language thing).

See commit-per-commit for an explanation of the whats and whys.