### PR TITLE
Implement priority based task scheduling.

### DIFF
--- a/source/vibe/core/core.d
+++ b/source/vibe/core/core.d
@@ -656,6 +656,19 @@ void runWorkerTaskDist(alias method, T, ARGS...)(shared(T) object, ARGS args)
 	setupWorkerThreads();
 	return st_workerPool.runTaskDist!method(object, args);
 }
+/// ditto
+void runWorkerTaskDist(FT, ARGS...)(TaskSettings settings, FT func, auto ref ARGS args)
+	if (is(typeof(*func) == function))
+{
+	setupWorkerThreads();
+	return st_workerPool.runTaskDist(settings, func, args);
+}
+/// ditto
+void runWorkerTaskDist(alias method, T, ARGS...)(TaskSettings settings, shared(T) object, ARGS args)
+{
+	setupWorkerThreads();
+	return st_workerPool.runTaskDist!method(settings, object, args);
+}
 
 
 /** Runs a new asynchronous task in all worker threads and returns the handles.
@@ -670,6 +683,13 @@ void runWorkerTaskDistH(HCB, FT, ARGS...)(scope HCB on_handle, FT func, auto ref
 {
 	setupWorkerThreads();
 	st_workerPool.runTaskDistH(on_handle, func, args);
+}
+/// ditto
+void runWorkerTaskDistH(HCB, FT, ARGS...)(TaskSettings settings, scope HCB on_handle, FT func, auto ref ARGS args)
+	if (is(typeof(*func) == function))
+{
+	setupWorkerThreads();
+	st_workerPool.runTaskDistH(settings, on_handle, func, args);
 }
 
 

--- a/source/vibe/core/core.d
+++ b/source/vibe/core/core.d
@@ -1,7 +1,7 @@
 /**
 	This module contains the core functionality of the vibe.d framework.
 
-	Copyright: © 2012-2019 Sönke Ludwig
+	Copyright: © 2012-2020 Sönke Ludwig
 	License: Subject to the terms of the MIT license, as written in the included LICENSE.txt file.
 	Authors: Sönke Ludwig
 */
@@ -319,7 +319,7 @@ Task runTask(ARGS...)(void delegate(ARGS) @safe task, auto ref ARGS args)
 {
 	return runTask_internal!((ref tfi) { tfi.set(task, args); });
 }
-///
+/// ditto
 Task runTask(ARGS...)(void delegate(ARGS) @system task, auto ref ARGS args)
 @system {
 	return runTask_internal!((ref tfi) { tfi.set(task, args); });
@@ -330,6 +330,50 @@ Task runTask(CALLABLE, ARGS...)(CALLABLE task, auto ref ARGS args)
 {
 	return runTask_internal!((ref tfi) { tfi.set(task, args); });
 }
+/// ditto
+Task runTask(ARGS...)(TaskSettings settings, void delegate(ARGS) @safe task, auto ref ARGS args)
+{
+	return runTask_internal!((ref tfi) {
+		tfi.settings = settings;
+		tfi.set(task, args);
+	});
+}
+/// ditto
+Task runTask(ARGS...)(TaskSettings settings, void delegate(ARGS) @system task, auto ref ARGS args)
+@system {
+	return runTask_internal!((ref tfi) {
+		tfi.settings = settings;
+		tfi.set(task, args);
+	});
+}
+/// ditto
+Task runTask(CALLABLE, ARGS...)(TaskSettings settings, CALLABLE task, auto ref ARGS args)
+	if (!is(CALLABLE : void delegate(ARGS)) && is(typeof(CALLABLE.init(ARGS.init))))
+{
+	return runTask_internal!((ref tfi) {
+		tfi.settings = settings;
+		tfi.set(task, args);
+	});
+}
+
+
+unittest { // test proportional priority scheduling
+	auto tm = setTimer(1000.msecs, { assert(false, "Test timeout"); });
+	scope (exit) tm.stop();
+
+	size_t a, b;
+	auto t1 = runTask(TaskSettings(1), { while (a + b < 100) { a++; yield(); } });
+	auto t2 = runTask(TaskSettings(10), { while (a + b < 100) { b++; yield(); } });
+	runTask({
+		t1.join();
+		t2.join();
+		exitEventLoop();
+	});
+	runEventLoop();
+	assert(a + b == 100);
+	assert(b.among(90, 91, 92)); // expect 1:10 ratio +-1
+}
+
 
 /**
 	Runs an asyncronous task that is guaranteed to finish before the caller's
@@ -429,6 +473,21 @@ void runWorkerTask(alias method, T, ARGS...)(shared(T) object, auto ref ARGS arg
 	setupWorkerThreads();
 	st_workerPool.runTask!method(object, args);
 }
+/// ditto
+void runWorkerTask(FT, ARGS...)(TaskSettings settings, FT func, auto ref ARGS args)
+	if (isFunctionPointer!FT)
+{
+	setupWorkerThreads();
+	st_workerPool.runTask(settings, func, args);
+}
+
+/// ditto
+void runWorkerTask(alias method, T, ARGS...)(TaskSettings settings, shared(T) object, auto ref ARGS args)
+	if (is(typeof(__traits(getMember, object, __traits(identifier, method)))))
+{
+	setupWorkerThreads();
+	st_workerPool.runTask!method(settings, object, args);
+}
 
 /**
 	Runs a new asynchronous task in a worker thread, returning the task handle.
@@ -451,6 +510,20 @@ Task runWorkerTaskH(alias method, T, ARGS...)(shared(T) object, auto ref ARGS ar
 {
 	setupWorkerThreads();
 	return st_workerPool.runTaskH!method(object, args);
+}
+/// ditto
+Task runWorkerTaskH(FT, ARGS...)(TaskSettings settings, FT func, auto ref ARGS args)
+	if (isFunctionPointer!FT)
+{
+	setupWorkerThreads();
+	return st_workerPool.runTaskH(settings, func, args);
+}
+/// ditto
+Task runWorkerTaskH(alias method, T, ARGS...)(TaskSettings settings, shared(T) object, auto ref ARGS args)
+	if (is(typeof(__traits(getMember, object, __traits(identifier, method)))))
+{
+	setupWorkerThreads();
+	return st_workerPool.runTaskH!method(settings, object, args);
 }
 
 /// Running a worker task using a function

--- a/source/vibe/core/taskpool.d
+++ b/source/vibe/core/taskpool.d
@@ -261,6 +261,12 @@ shared final class TaskPool {
 		See_also: `runTaskDist`
 	*/
 	void runTaskDistH(HCB, FT, ARGS...)(scope HCB on_handle, FT func, auto ref ARGS args)
+		if (!is(HCB == TaskSettings))
+	{
+		runTaskDistH(TaskSettings.init, on_handle, func, args);
+	}
+	/// ditto
+	void runTaskDistH(HCB, FT, ARGS...)(TaskSettings settings, scope HCB on_handle, FT func, auto ref ARGS args)
 	{
 		// TODO: support non-copyable argument types using .move
 		import std.concurrency : send, receiveOnly;
@@ -277,7 +283,7 @@ shared final class TaskPool {
 			t.tid.send(Task.getThis());
 			func(args);
 		}
-		runTaskDist(&call, caller, func, args);
+		runTaskDist(settings, &call, caller, func, args);
 
 		foreach (i; 0 .. this.threadCount)
 			on_handle(receiveOnly!Task);

--- a/source/vibe/core/taskpool.d
+++ b/source/vibe/core/taskpool.d
@@ -1,7 +1,7 @@
 /**
 	Multi-threaded task pool implementation.
 
-	Copyright: © 2012-2017 Sönke Ludwig
+	Copyright: © 2012-2020 Sönke Ludwig
 	License: Subject to the terms of the MIT license, as written in the included LICENSE.txt file.
 	Authors: Sönke Ludwig
 */
@@ -11,7 +11,7 @@ import vibe.core.concurrency : isWeaklyIsolated;
 import vibe.core.core : exitEventLoop, logicalProcessorCount, runEventLoop, runTask, runTask_internal;
 import vibe.core.log;
 import vibe.core.sync : ManualEvent, Monitor, createSharedManualEvent, createMonitor;
-import vibe.core.task : Task, TaskFuncInfo, callWithMove;
+import vibe.core.task : Task, TaskFuncInfo, TaskSettings, callWithMove;
 import core.sync.mutex : Mutex;
 import core.thread : Thread;
 import std.concurrency : prioritySend, receiveOnly;
@@ -113,16 +113,30 @@ shared final class TaskPool {
 		if (isFunctionPointer!FT)
 	{
 		foreach (T; ARGS) static assert(isWeaklyIsolated!T, "Argument type "~T.stringof~" is not safe to pass between threads.");
-		runTask_unsafe(func, args);
+		runTask_unsafe(TaskSettings.init, func, args);
 	}
-
 	/// ditto
 	void runTask(alias method, T, ARGS...)(shared(T) object, auto ref ARGS args)
 		if (is(typeof(__traits(getMember, object, __traits(identifier, method)))))
 	{
 		foreach (T; ARGS) static assert(isWeaklyIsolated!T, "Argument type "~T.stringof~" is not safe to pass between threads.");
 		auto func = &__traits(getMember, object, __traits(identifier, method));
-		runTask_unsafe(func, args);
+		runTask_unsafe(TaskSettings.init, func, args);
+	}
+	/// ditto
+	void runTask(FT, ARGS...)(TaskSettings settings, FT func, auto ref ARGS args)
+		if (isFunctionPointer!FT)
+	{
+		foreach (T; ARGS) static assert(isWeaklyIsolated!T, "Argument type "~T.stringof~" is not safe to pass between threads.");
+		runTask_unsafe(settings, func, args);
+	}
+	/// ditto
+	void runTask(alias method, T, ARGS...)(TaskSettings settings, shared(T) object, auto ref ARGS args)
+		if (is(typeof(__traits(getMember, object, __traits(identifier, method)))))
+	{
+		foreach (T; ARGS) static assert(isWeaklyIsolated!T, "Argument type "~T.stringof~" is not safe to pass between threads.");
+		auto func = &__traits(getMember, object, __traits(identifier, method));
+		runTask_unsafe(settings, func, args);
 	}
 
 	/** Runs a new asynchronous task in a worker thread, returning the task handle.
@@ -141,9 +155,9 @@ shared final class TaskPool {
 		// workaround for runWorkerTaskH to work when called outside of a task
 		if (Task.getThis() == Task.init) {
 			Task ret;
-			.runTask({ ret = doRunTaskH(func, args); }).join();
+			.runTask({ ret = doRunTaskH(TaskSettings.init, func, args); }).join();
 			return ret;
-		} else return doRunTaskH(func, args);
+		} else return doRunTaskH(TaskSettings.init, func, args);
 	}
 	/// ditto
 	Task runTaskH(alias method, T, ARGS...)(shared(T) object, auto ref ARGS args)
@@ -154,10 +168,32 @@ shared final class TaskPool {
 		}
 		return runTaskH(&wrapper!(), object, args);
 	}
+	/// ditto
+	Task runTaskH(FT, ARGS...)(TaskSettings settings, FT func, auto ref ARGS args)
+		if (isFunctionPointer!FT)
+	{
+		foreach (T; ARGS) static assert(isWeaklyIsolated!T, "Argument type "~T.stringof~" is not safe to pass between threads.");
+
+		// workaround for runWorkerTaskH to work when called outside of a task
+		if (Task.getThis() == Task.init) {
+			Task ret;
+			.runTask({ ret = doRunTaskH(settings, func, args); }).join();
+			return ret;
+		} else return doRunTaskH(settings, func, args);
+	}
+	/// ditto
+	Task runTaskH(alias method, T, ARGS...)(TaskSettings settings, shared(T) object, auto ref ARGS args)
+		if (is(typeof(__traits(getMember, object, __traits(identifier, method)))))
+	{
+		static void wrapper()(shared(T) object, ref ARGS args) {
+			__traits(getMember, object, __traits(identifier, method))(args);
+		}
+		return runTaskH(settings, &wrapper!(), object, args);
+	}
 
 	// NOTE: needs to be a separate function to avoid recursion for the
 	//       workaround above, which breaks @safe inference
-	private Task doRunTaskH(FT, ARGS...)(FT func, ref ARGS args)
+	private Task doRunTaskH(FT, ARGS...)(TaskSettings settings, FT func, ref ARGS args)
 		if (isFunctionPointer!FT)
 	{
 		import std.typecons : Typedef;
@@ -173,7 +209,7 @@ shared final class TaskPool {
 			caller.tid.prioritySend(callee);
 			mixin(callWithMove!ARGS("func", "args"));
 		}
-		runTask_unsafe(&taskFun, caller, func, args);
+		runTask_unsafe(settings, &taskFun, caller, func, args);
 		return cast(Task)() @trusted { return receiveOnly!PrivateTask(); } ();
 	}
 
@@ -191,7 +227,7 @@ shared final class TaskPool {
 		if (is(typeof(*func) == function))
 	{
 		foreach (T; ARGS) static assert(isWeaklyIsolated!T, "Argument type "~T.stringof~" is not safe to pass between threads.");
-		runTaskDist_unsafe(func, args);
+		runTaskDist_unsafe(TaskSettings.init, func, args);
 	}
 	/// ditto
 	void runTaskDist(alias method, T, ARGS...)(shared(T) object, auto ref ARGS args)
@@ -199,7 +235,22 @@ shared final class TaskPool {
 		auto func = &__traits(getMember, object, __traits(identifier, method));
 		foreach (T; ARGS) static assert(isWeaklyIsolated!T, "Argument type "~T.stringof~" is not safe to pass between threads.");
 
-		runTaskDist_unsafe(func, args);
+		runTaskDist_unsafe(TaskSettings.init, func, args);
+	}
+	/// ditto
+	void runTaskDist(FT, ARGS...)(TaskSettings settings, FT func, auto ref ARGS args)
+		if (is(typeof(*func) == function))
+	{
+		foreach (T; ARGS) static assert(isWeaklyIsolated!T, "Argument type "~T.stringof~" is not safe to pass between threads.");
+		runTaskDist_unsafe(settings, func, args);
+	}
+	/// ditto
+	void runTaskDist(alias method, T, ARGS...)(TaskSettings settings, shared(T) object, auto ref ARGS args)
+	{
+		auto func = &__traits(getMember, object, __traits(identifier, method));
+		foreach (T; ARGS) static assert(isWeaklyIsolated!T, "Argument type "~T.stringof~" is not safe to pass between threads.");
+
+		runTaskDist_unsafe(settings, func, args);
 	}
 
 	/** Runs a new asynchronous task in all worker threads and returns the handles.
@@ -232,7 +283,7 @@ shared final class TaskPool {
 			on_handle(receiveOnly!Task);
 	}
 
-	private void runTask_unsafe(CALLABLE, ARGS...)(CALLABLE callable, ref ARGS args)
+	private void runTask_unsafe(CALLABLE, ARGS...)(TaskSettings settings, CALLABLE callable, ref ARGS args)
 	{
 		import std.traits : ParameterTypeTuple;
 		import vibe.internal.traits : areConvertibleTo;
@@ -242,11 +293,11 @@ shared final class TaskPool {
 		static assert(areConvertibleTo!(Group!ARGS, Group!FARGS),
 			"Cannot convert arguments '"~ARGS.stringof~"' to function arguments '"~FARGS.stringof~"'.");
 
-		m_state.lock.queue.put(callable, args);
+		m_state.lock.queue.put(settings, callable, args);
 		m_signal.emitSingle();
 	}
 
-	private void runTaskDist_unsafe(CALLABLE, ARGS...)(ref CALLABLE callable, ARGS args) // NOTE: no ref for args, to disallow non-copyable types!
+	private void runTaskDist_unsafe(CALLABLE, ARGS...)(TaskSettings settings, ref CALLABLE callable, ARGS args) // NOTE: no ref for args, to disallow non-copyable types!
 	{
 		import std.traits : ParameterTypeTuple;
 		import vibe.internal.traits : areConvertibleTo;
@@ -260,7 +311,7 @@ shared final class TaskPool {
 			auto st = m_state.lock;
 			foreach (thr; st.threads) {
 				// create one TFI per thread to properly account for elaborate assignment operators/postblit
-				thr.m_queue.put(callable, args);
+				thr.m_queue.put(settings, callable, args);
 			}
 		}
 		m_signal.emit();
@@ -355,12 +406,13 @@ nothrow @safe:
 
 	@property size_t length() const { return m_queue.length; }
 
-	void put(CALLABLE, ARGS...)(ref CALLABLE c, ref ARGS args)
+	void put(CALLABLE, ARGS...)(TaskSettings settings, ref CALLABLE c, ref ARGS args)
 	{
 		import std.algorithm.comparison : max;
 		if (m_queue.full) m_queue.capacity = max(16, m_queue.capacity * 3 / 2);
 		assert(!m_queue.full);
 
+		m_queue.peekDst[0].settings = settings;
 		m_queue.peekDst[0].set(c, args);
 		m_queue.putN(1);
 	}

--- a/tests/issue-161-multiple-joiners.d
+++ b/tests/issue-161-multiple-joiners.d
@@ -23,6 +23,9 @@ void main()
 		t.join();
 	});
 
+	// let the outer task run and start the inner task
+	yield();
+	// let the outer task get another execution slice to write to t
 	yield();
 
 	assert(t && t.running);


### PR DESCRIPTION
1. Removes the marker task used by schedule() and instead limits the number of task resumptions to the initial length of the task queue
2. Assigns a static and a dynamic priority to each task. The dynamic priority starts with the same value as the static priority and gets incremented by the static priority each time the task gets overtaken by a higher priority task, eventually leading to the task becoming the highest priority (unless the static priority is zero). Tasks with a higher dynamic priority generally take precedence, unless the concurrency exceeds 10 scheduled tasks, in which case the front of the queue is scheduled in normal FIFO order.