### PR TITLE
Remove potentially blocking file I/O code (upgrade to eventcore 0.9.0).

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -4,7 +4,7 @@ authors "Sönke Ludwig"
 copyright "Copyright © 2016-2020, Sönke Ludwig"
 license "MIT"
 
-dependency "eventcore" version="~>0.8.43"
+dependency "eventcore" version="~>0.9.0"
 dependency "stdx-allocator" version="~>2.77.0"
 
 targetName "vibe_core"

--- a/source/vibe/core/internal/release.d
+++ b/source/vibe/core/internal/release.d
@@ -1,6 +1,7 @@
 module vibe.core.internal.release;
 
 import eventcore.core;
+import std.stdint : intptr_t;
 
 /// Release a handle in a thread-safe way
 void releaseHandle(string subsys, H)(H handle, shared(NativeEventDriver) drv)
@@ -19,8 +20,8 @@ void releaseHandle(string subsys, H)(H handle, shared(NativeEventDriver) drv)
 
 		// in case the destructor was called from a foreign thread,
 		// perform the release in the owner thread
-		drv.core.runInOwnerThread((h) {
-			__traits(getMember, eventDriver, subsys).releaseRef(cast(H)h);
-		}, cast(size_t)handle);
+		drv.core.runInOwnerThread((H handle) {
+			__traits(getMember, eventDriver, subsys).releaseRef(handle);
+		}, handle);
 	}
 }

--- a/source/vibe/core/process.d
+++ b/source/vibe/core/process.d
@@ -453,7 +453,14 @@ struct PipeInputStream {
     */
     void close()
     nothrow {
-        eventDriver.pipes.close(m_pipe);
+		if (m_pipe == PipeFD.invalid) return;
+
+		asyncAwaitUninterruptible!(PipeCloseCallback,
+			cb => eventDriver.pipes.close(m_pipe, cb)
+		);
+
+		eventDriver.pipes.releaseRef(m_pipe);
+		m_pipe = PipeFD.invalid;
     }
 }
 
@@ -528,7 +535,14 @@ struct PipeOutputStream {
     */
     void close()
     nothrow {
-        eventDriver.pipes.close(m_pipe);
+		if (m_pipe == PipeFD.invalid) return;
+
+		asyncAwaitUninterruptible!(PipeCloseCallback,
+			cb => eventDriver.pipes.close(m_pipe, cb)
+		);
+
+		eventDriver.pipes.releaseRef(m_pipe);
+		m_pipe = PipeFD.invalid;
     }
 }
 


### PR DESCRIPTION
- file and pipe closing are now asynchronous operations
- moveFile and removeFile are now executed in a worker thread
- requires eventcore ~>0.9.0