### PR TITLE
Change a unittest that test for 'in' => 'const' lowering

### DIFF
--- a/source/vibe/internal/traits.d
+++ b/source/vibe/internal/traits.d
@@ -511,8 +511,16 @@ unittest {
 		void write(InputStream stream, ulong nbytes) {}
 	}
 
-	static assert(checkInterfaceConformance!(NonOSStruct2, OutputStream) ==
-		"NonOSStruct2 does not implement method \"write\" of type @safe void(const(ubyte[]) bytes)");
+    // `in` used to show up as `const` / `const scope`.
+    // With dlang/dmd#11474 it shows up as `in`.
+    // Remove when support for v2.093.0 is dropped
+    static if (checkInterfaceConformance!(NonOSStruct2, OutputStream) !=
+        "NonOSStruct2 does not implement method \"write\" of type @safe void(in ubyte[] bytes)")
+    {
+        // Fallback to pre-2.092+
+        static assert(checkInterfaceConformance!(NonOSStruct2, OutputStream) ==
+            "NonOSStruct2 does not implement method \"write\" of type @safe void(const(ubyte[]) bytes)");
+    }
 }
 
 string functionAttributeString(alias F)(bool restrictions_only)


### PR DESCRIPTION
```
As explained in details in dlang/dmd#11000 and dlang/dmd#11474,
'in' has been for a very long time lowered to simply 'const',
or 'scope const' when v2.092.0's '-preview=in' switch is used.
DMD PR 11474 aims to change this, so 'in' is not (visibly)
lowered, and shows up in any user-visible string.
This includes header generation, error messages, and stringof.
Since this code was testing stringof directly, it is affected
by the change. To support testing of both aforementioned DMD PRs,
the change is not tied to a version,
but uses the (soon-to-be) old way as a fallback.
```

Supporting https://github.com/dlang/dmd/pull/11474
@s-ludwig : Can I get a minor release with this (I can do it myself if that's okay with you).