### PR TITLE
Remove unused import to enforceEx

### DIFF
--- a/source/vibe/internal/freelistref.d
+++ b/source/vibe/internal/freelistref.d
@@ -17,7 +17,6 @@ import core.exception : OutOfMemoryError;
 import core.stdc.stdlib;
 import core.memory;
 import std.conv;
-import std.exception : enforceEx;
 import std.traits;
 import std.algorithm;
 


### PR DESCRIPTION
This function wasn't used anymore, but still imported, despite being deprecated.
It was scheduled to be removed a few releases ago (see dlang/phobos#7545).