### PR TITLE
Fix waitForDataEx's return value for an open connection and a zero timeout

### DIFF
--- a/source/vibe/core/net.d
+++ b/source/vibe/core/net.d
@@ -612,7 +612,10 @@ mixin(tracer);
 		asyncAwaitAny!(true, waiter)(timeout);
 
 		if (!m_context) return WaitForDataStatus.noMoreData;
-		if (cancelled) return WaitForDataStatus.timeout;
+		// NOTE: for IOMode.immediate, no actual timeout occurrs, but the read
+		//       fails immediately with wouldBlock
+		if (cancelled || status == IOStatus.wouldBlock)
+			return WaitForDataStatus.timeout;
 
 		logTrace("Socket %s, read %s bytes: %s", m_socket, nbytes, status);
 


### PR DESCRIPTION
`IOMode.once` causes the `read()` call to return with `IOStatus.wouldBlock` immediately, which previously resulted in erroneously reporting `WaitForDataStatus.noModeData` instead of `timeout`.

See vibe-d/vibe.d#2483