### PR TITLE
Fix a worker task scheduling issue for busy worker tasks.

### DIFF
--- a/source/vibe/core/sync.d
+++ b/source/vibe/core/sync.d
@@ -132,7 +132,7 @@ struct ScopedMutexLock(M)
 	@property bool locked() const { return m_locked; }
 
 	void unlock()
-	in (this.locked)
+	in { assert(this.locked); }
 	do {
 		enforce(m_locked);
 		m_mutex.unlock();
@@ -140,13 +140,13 @@ struct ScopedMutexLock(M)
 	}
 
 	bool tryLock()
-	in (!this.locked)
+	in { assert(!this.locked); }
 	do {
 		return m_locked = m_mutex.tryLock();
 	}
 
 	void lock()
-	in (!this.locked)
+	in { assert(!this.locked); }
 	do {
 		m_locked = true;
 		m_mutex.lock();


### PR DESCRIPTION
Fixes new tasks being able to be scheduled on a worker thread while a busy task (that periodically calls yield()) is running.