### PR TITLE
Introduce ChannelConfig/ChannelPriority.

### DIFF
--- a/source/vibe/core/log.d
+++ b/source/vibe/core/log.d
@@ -839,6 +839,7 @@ unittest
 		logger.endLine();
 	}
 	auto path = fstream.path;
+	destroy(logger);
 	fstream.close();
 
 	import std.file;

--- a/source/vibe/core/log.d
+++ b/source/vibe/core/log.d
@@ -642,7 +642,7 @@ final class SyslogLogger(OutputStream) : Logger {
 		string m_hostName;
 		string m_appName;
 		OutputStream m_ostream;
-		Facility m_facility;
+		SyslogFacility m_facility;
 	}
 
 	deprecated("Use `SyslogFacility` instead.")
@@ -680,7 +680,7 @@ final class SyslogLogger(OutputStream) : Logger {
 		Logger uses the stream's write function when it logs and would hence
 		log forevermore.
 	*/
-	this(OutputStream stream, Facility facility, string appName = null, string hostName = hostName())
+	this(OutputStream stream, SyslogFacility facility, string appName = null, string hostName = hostName())
 	{
 		m_hostName = hostName != "" ? hostName : NILVALUE;
 		m_appName = appName != "" ? appName : NILVALUE;


### PR DESCRIPTION
Adds a low-overhead mode to Channel!T that causes the buffer to be fully processed before notifying waiting peers instead of notifying immediately once data/space is available. This heavily reduces the overhead of cross-task/thread notifications at the expense of introducing processing latency and requiring a call to close() to guarantee that all data has been processed.