### PR TITLE
Rework the listDirectory implementation

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -13,9 +13,11 @@ mainSourceFile "source/vibe/appmain.d"
 
 configuration "winapi" {
 	subConfiguration "eventcore" "winapi"
+	versions "Windows7"
 }
 configuration "winapi-optlink" {
 	subConfiguration "eventcore" "winapi-optlink"
+	versions "Windows7"
 }
 configuration "epoll" {
 	subConfiguration "eventcore" "epoll"
@@ -28,9 +30,11 @@ configuration "kqueue" {
 }
 configuration "select" {
 	subConfiguration "eventcore" "select"
+	versions "Windows7" platform="win"
 }
 configuration "select-optlink" {
 	subConfiguration "eventcore" "select-optlink"
+	versions "Windows7" platform="win"
 }
 configuration "libasync" {
 	subConfiguration "eventcore" "libasync"

--- a/source/vibe/core/log.d
+++ b/source/vibe/core/log.d
@@ -839,6 +839,7 @@ unittest
 		logger.endLine();
 	}
 	auto path = fstream.path;
+	destroy(logger);
 	fstream.close();
 
 	import std.file;

--- a/source/vibe/core/log.d
+++ b/source/vibe/core/log.d
@@ -642,7 +642,7 @@ final class SyslogLogger(OutputStream) : Logger {
 		string m_hostName;
 		string m_appName;
 		OutputStream m_ostream;
-		Facility m_facility;
+		SyslogFacility m_facility;
 	}
 
 	deprecated("Use `SyslogFacility` instead.")
@@ -680,7 +680,7 @@ final class SyslogLogger(OutputStream) : Logger {
 		Logger uses the stream's write function when it logs and would hence
 		log forevermore.
 	*/
-	this(OutputStream stream, Facility facility, string appName = null, string hostName = hostName())
+	this(OutputStream stream, SyslogFacility facility, string appName = null, string hostName = hostName())
 	{
 		m_hostName = hostName != "" ? hostName : NILVALUE;
 		m_appName = appName != "" ? appName : NILVALUE;


### PR DESCRIPTION
- Directly uses OS facilities instead of Phobos to avoid string processing overhead and to enable fast skipping of non-directories
- Introduces a DirectoryListMode, similar to SpanMode
- Uses low-overhead channels to reduce the communication overhead between the calling thread and the worker thread that calls the OS
- Adds FileInfo.path to properly support the new recursive directory iteration schemes

Note that this should only be merged once #241 is merged and this is rebased.