### PR TITLE
WIP: Add Meson support

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,98 @@
+# Meson file for Vibe Core
+project(
+    'Vibe Core', 
+    'd',
+    version: '1.13.1'
+)
+
+project_soversion      = '0'
+project_version_suffix = ''
+project_version        = meson.project_version()
+project_version_full   = project_version + project_version_suffix
+
+source_root = meson.source_root()
+build_root = meson.build_root()
+
+pkgc = import('pkgconfig')
+
+# Dependencies
+eventcore_dep = dependency('eventcore', version: '>=0.9.2')
+stdx_allocator_dep = dependency('stdx-allocator', version: '>=2.77.0')
+
+vibe_core_deps = [eventcore_dep, stdx_allocator_dep]
+vibe_core_src_dir = include_directories('source')
+
+vibe_core_src = [
+    'source/vibe/appmain.d',
+    'source/vibe/core/args.d',
+    'source/vibe/core/channel.d',
+    'source/vibe/core/concurrency.d',
+    'source/vibe/core/connectionpool.d',
+    'source/vibe/core/core.d',
+    'source/vibe/core/file.d',
+    'source/vibe/core/internal/release.d',
+    'source/vibe/core/log.d',
+    'source/vibe/core/net.d',
+    'source/vibe/core/parallelism.d',
+    'source/vibe/core/path.d',
+    'source/vibe/core/process.d',
+    'source/vibe/core/stream.d',
+    'source/vibe/core/sync.d',
+    'source/vibe/core/task.d',
+    'source/vibe/core/taskpool.d',
+    'source/vibe/internal/allocator.d',
+    'source/vibe/internal/array.d',
+    'source/vibe/internal/async.d',
+    'source/vibe/internal/freelistref.d',
+    'source/vibe/internal/hashmap.d',
+    'source/vibe/internal/interfaceproxy.d',
+    'source/vibe/internal/list.d',
+    'source/vibe/internal/string.d',
+    'source/vibe/internal/traits.d',
+    'source/vibe/internal/typetuple.d',
+]
+
+#
+# Install Includes
+#
+install_subdir('source/vibe/', install_dir: 'include/d/vibe/')
+
+
+#
+# Build Targets
+#
+
+# Basic I/O and concurrency primitives, as well as low level utility functions
+vibe_core_lib = library('vibe-core',
+    [vibe_core_src],
+    include_directories: vibe_core_src_dir,
+    install: true,
+    dependencies: vibe_core_deps,
+    version: project_version,
+    soversion: project_soversion
+)
+pkgc.generate(name: 'vibe-core',
+    libraries: [vibe_core_lib],
+    requires: ['eventcore', 'stdx-allocator'],
+    subdirs: 'd/vibe',
+    version: project_version,
+    description: 'Basic I/O and concurrency primitives, as well as low level utility functions of Vibe.'
+)
+
+vibe_core_dep = declare_dependency(
+    link_with: vibe_core_lib,
+    include_directories: vibe_core_src_dir,
+    dependencies: vibe_core_deps,
+)
+
+#
+# Tests
+#
+vibe_test_core_exe = executable('vibe-test_core',
+    [vibe_core_src],
+    d_unittest: true,
+    dependencies: [vibe_core_dep],
+    d_args: meson.get_compiler('d').unittest_args(),
+    link_args: '-main'
+)
+test('vibe-test_core', vibe_test_core_exe)


### PR DESCRIPTION
When vibe-core was split off vibe.d itself, Meson support was broken. This adds it back in, based of the original Meson code when it was in the vibe.d project.

Should be a step towards resolving https://github.com/vibe-d/vibe.d/issues/2531

Depends on: \<merge request no. in eventcore\>

Right now, some of the unit tests seem to be broken. I have no idea what causes it, which is why this is marked as WIP:
```
chris@roku ~/Code/D/vibe-core/build (git)-[master] % ninja test
[0/1] Regenerating build files.
The Meson build system
Version: 0.57.1
Source dir: /home/chris/Code/D/vibe-core
Build dir: /home/chris/Code/D/vibe-core/build
Build type: native build
Project name: Vibe Core
Project version: 1.13.1
D compiler for the host machine: ldc2 (llvm 1.25.0 "LDC - the LLVM D compiler (1.25.0):")
D linker for the host machine: ldc2 ld.gold 2.36.1
Host machine cpu family: x86_64
Host machine cpu: x86_64
Dependency eventcore found: YES 0.9.13 (cached)
Dependency stdx-allocator found: YES 3.0.1 (cached)
Build targets in project: 2

Found ninja-1.10.2 at /usr/bin/ninja
[0/1] Running all tests.
1/1 vibe-test_core        FAIL            0.13s   killed by signal 6 SIGABRT
>>> MALLOC_PERTURB_=44 /home/chris/Code/D/vibe-core/build/vibe-test_core
―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― ✀  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――
stderr:
core.exception.AssertError@../source/vibe/core/args.d(57): readOption() may only be called once per option name.
----------------
??:? _d_assert_msg [0x7f6cf44fe649]
args.d:57 bool vibe.core.args.readOption!(bool).readOption(immutable(char)[], bool*, immutable(char)[]) [0x555eab07defa]
log.d:920 void vibe.core.log.initializeLogModule() [0x555eab1775ee]
core.d:1529 void vibe.core.core._sharedStaticCtor_L1520_C1() [0x555eab1355bc]
??:? int rt.minfo.rt_moduleCtor().__foreachbody1(ref rt.sections_elf_shared.DSO) [0x7f6cf453d448]
??:? int rt.sections_elf_shared.DSO.opApply(scope int delegate(ref rt.sections_elf_shared.DSO)) [0x7f6cf453e578]
??:? rt_init [0x7f6cf4533457]
??:? void rt.dmain2._d_run_main2(char[][], ulong, extern (C) int function(char[][])*).runAll() [0x7f6cf45339dc]
??:? _d_run_main2 [0x7f6cf4533837]
??:? _d_run_main [0x7f6cf453368d]
??:? [0x555eab07d214]
??:? __libc_start_main [0x7f6cf411cb24]
??:? [0x555eab07d10d]
uncaught exception
core.exception.AssertError@../source/vibe/core/core.d(1600): No more threads registered
----------------
??:? _d_assert_msg [0x7f6cf44fe649]
core.d:1600 void vibe.core.core._staticDtor_L1582_C1() [0x555eab135fa3]
??:? void rt.minfo.ModuleGroup.runTlsDtors() [0x7f6cf453d0e9]
??:? _d_dso_registry [0x7f6cf453f160]
??:? [0x7f6cf4d71aad]
??:? [0x7f6cf4eee23a]
??:? [0x7f6cf4134696]
??:? exit [0x7f6cf413483d]
??:? __libc_start_main [0x7f6cf411cb2b]
??:? [0x555eab07d10d]
――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――
```