### PR TITLE
Remove noisy trace log

### DIFF
--- a/source/vibe/core/sync.d
+++ b/source/vibe/core/sync.d
@@ -1025,15 +1025,12 @@ struct ManualEvent {
 	shared nothrow @trusted {
 		import core.atomic : atomicOp, cas;
 
-		() @trusted { logTrace("emit shared %s", cast(void*)&this); } ();
-
 		auto ec = atomicOp!"+="(m_emitCount, 1);
 		auto thisthr = Thread.getThis();
 
 		ThreadWaiter lw;
 		auto drv = eventDriver;
 		m_waiters.lock.active.filter((ThreadWaiter w) {
-			() @trusted { logTrace("waiter %s", cast(void*)w); } ();
 			if (w.m_driver is drv) {
 				lw = w;
 				lw.addRef();
@@ -1045,13 +1042,10 @@ struct ManualEvent {
 			}
 			return true;
 		});
-		() @trusted { logTrace("lw %s", cast(void*)lw); } ();
 		if (lw) {
 			lw.emit();
 			releaseWaiter(lw);
 		}
-
-		logTrace("emit shared done");
 
 		return ec;
 	}


### PR DESCRIPTION
```
When a user enable trace logs, the 'emit shared done' and 'lw ...' messages
are displayed often, even when nothing user-related is happening.
This makes the log a little less verbose so that one can focus
on more user-relevant informations, such as the content of HTTP headers.
```

@s-ludwig : One thing I'm really missing in Vibe.d's logging capabilities is categorization. For example, take a look at Ocean's logger:
https://github.com/sociomantic-tsunami/ocean/blob/b230b02c63d946d686c344fda63cd4ef4a003c2c/src/ocean/util/log/Logger.d#L12-L29

The output for our app [looks like this](https://github.com/bpfkorea/agora/blob/d5d2928f27fc07204213eeef836b404ed6de7379/source/agora/consensus/protocol/Nominator.d#L417):
```
2021-03-14 10:40:36,495 Info [agora.consensus.protocol.Nominator] - agora.consensus.protocol.Nominator.Nominator.nominate(): Proposing tx set for slot 240
```

Would be good to have something similar in Vibe.d.