### PR TITLE
Make LocalTaskSemaphore.this nothrow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ jobs:
     test:
         name: Dub Tests
         strategy:
+            fail-fast: false
             matrix:
                 os: [ubuntu-latest, windows-latest, macOS-latest]
                 dc: [dmd-latest, ldc-latest]

--- a/source/vibe/core/sync.d
+++ b/source/vibe/core/sync.d
@@ -211,7 +211,7 @@ final class LocalTaskSemaphore
 		LocalManualEvent m_signal;
 	}
 
-	this(uint max_locks)
+	this(uint max_locks) nothrow
 	{
 		m_maxLocks = max_locks;
 		m_signal = createManualEvent();


### PR DESCRIPTION
```
vibe-core ~master: building configuration "vibe-core-test-cfrunloop"...
source/vibe/core/sync.d(214,2): Deprecation: `vibe.core.sync.LocalTaskSemaphore.this` has stricter attributes than its destructor (`@system`)
source/vibe/core/sync.d(214,2):        The destructor will be called if an exception is thrown
source/vibe/core/sync.d(214,2):        Either make the constructor `nothrow` or adjust the field destructors
```