### PR TITLE
Fix #267 - don't close `pipe()` filedescriptors before use

### DIFF
--- a/tests/issue-267-pipe.d
+++ b/tests/issue-267-pipe.d
@@ -1,0 +1,17 @@
+/+ dub.sdl:
+	name "tests"
+	dependency "vibe-core" path=".."
++/
+module tests;
+import core.time, vibe.core.core, vibe.core.process;
+
+void main()
+{
+    auto p = pipe();
+    runTask(()
+    {
+        sleep(10.msecs);
+        exitEventLoop();
+    });
+    runEventLoop();
+}


### PR DESCRIPTION
Basically direct use of what is `std.process.pipe()` using [internally](https://github.com/dlang/phobos/blob/b2019ebab00cac223a0f2e3ae6104f2290fb3079/std/process.d#L2620) but without intermediate `File`s that causes the problem.

I've tried to add the windows side as well, but it's not supported with eventcore winapi driver anyway.