### PR TITLE
Fixed fstatat linking on macOS/Apple M1 combination.

### DIFF
--- a/source/vibe/core/file.d
+++ b/source/vibe/core/file.d
@@ -1208,8 +1208,12 @@ version (Posix) {
 			 int dirfd(DIR*);
 		static if (!is(typeof(fstatat))) {
 			version (OSX) {
-				pragma(mangle, "fstatat$INODE64")
-				int fstatat(int dirfd, const(char)* pathname, stat_t *statbuf, int flags);
+    				version (x86_64) {
+					pragma(mangle, "fstatat$INODE64")
+					int fstatat(int dirfd, const(char)* pathname, stat_t *statbuf, int flags);
+    				} else {
+        				int fstatat(int dirfd, const(char)* pathname, stat_t *statbuf, int flags);
+    				}
 			} else int fstatat(int dirfd, const(char)* pathname, stat_t *statbuf, int flags);
 		}
 	}


### PR DESCRIPTION
Fix #269 to allow native arm64 compiled version to link with system files on Apple M1/Big Sur.