### PR TITLE
Remove deprecated aliases and functions in GenericPath

### DIFF
--- a/source/vibe/core/path.d
+++ b/source/vibe/core/path.d
@@ -203,11 +203,6 @@ alias InetPath = GenericPath!InetPathFormat;
 version (Windows) alias NativePath = WindowsPath;
 else alias NativePath = PosixPath;
 
-deprecated("Use NativePath or one the specific path types instead.")
-alias Path = NativePath;
-deprecated("Use NativePath.Segment or one the specific path types instead.")
-alias PathEntry = Path.Segment;
-
 /// Provides a common interface to operate on paths of various kinds.
 struct GenericPath(F) {
 @safe:
@@ -269,12 +264,6 @@ struct GenericPath(F) {
 			return ret;
 		}
 
-		deprecated("Use the constructor instead.")
-		static Segment validateFilename(string name)
-		{
-			return Segment(name);
-		}
-
 		/// The (file/directory) name of the path segment.
 		@property string name() const nothrow @nogc { return m_name; }
 		/// The trailing separator (e.g. `'/'`) or `'\0'`.
@@ -287,9 +276,6 @@ struct GenericPath(F) {
 		}
 		/// Returns `true` $(I iff) the segment has a trailing path separator.
 		@property bool hasSeparator() const nothrow @nogc { return m_separator != '\0'; }
-
-		deprecated("Use .name instead.")
-		string toString() const nothrow @nogc { return m_name; }
 
 		/** Converts the segment to another path type.
 


### PR DESCRIPTION
Those deprecations were added in commit 07e077a0098be467496f43199de178a4a0dcb6b9,
dated 2017-06-19 and part of the very first release (v1.0.0, 2017-07-10).
The toString deprecation is the most prominent one, as it triggers under conditions
which the user can't fix, such as when calling format or similar.

CC @s-ludwig , our build logs are pristine save for this:
<img width="960" alt="Screen Shot 2021-05-13 at 11 15 28" src="https://user-images.githubusercontent.com/2180215/118069861-ea9a6d00-b3df-11eb-8d56-792ab288ee87.png">

Because we use `-checkaction=context` which in turns calls `toString`.