### PR TITLE
Avoid creating unnecessary thread drivers at thread shutdown

### DIFF
--- a/source/vibe/core/core.d
+++ b/source/vibe/core/core.d
@@ -1761,7 +1761,11 @@ private void shutdownDriver()
 		ManualEvent.ms_threadEvent = EventID.init;
 	}
 
-	eventDriver.dispose();
+	static if (is(typeof(tryGetEventDriver()))) {
+		// avoid creating an event driver on threads that don't actually have one
+		if (auto drv = tryGetEventDriver())
+			drv.dispose();
+	} else eventDriver.dispose();
 }
 
 


### PR DESCRIPTION
See also vibe-d/eventcore#178.