### PR TITLE
core.file: Fix -preview=in support

### DIFF
--- a/source/vibe/core/file.d
+++ b/source/vibe/core/file.d
@@ -813,7 +813,7 @@ struct DirectoryWatcher { // TODO: avoid all those heap allocations!
 		// Support for `-preview=in`
 		static if (!is(typeof(mixin(q{(in ref int a) => a}))))
 		{
-			void onChange(WatcherID id, in FileChange change) nothrow {
+			void onChange(WatcherID id, const scope ref FileChange change) nothrow {
 				this.onChangeImpl(id, change);
 			}
 		} else {


### PR DESCRIPTION
This was erroring out because in and 'const scope ref' are not covariant.