### PR TITLE
Minor compatibility fixes for upcoming release

### DIFF
--- a/source/vibe/core/log.d
+++ b/source/vibe/core/log.d
@@ -408,8 +408,7 @@ final class FileLogger : Logger {
 			case Format.threadTime:
 				dst.put('[');
 				auto tm = msg.time;
-				static if (is(typeof(tm.fracSecs))) auto msecs = tm.fracSecs.total!"msecs"; // 2.069 has deprecated "fracSec"
-				else auto msecs = tm.fracSec.msecs;
+			    auto msecs = tm.fracSecs.total!"msecs";
 				m_curFile.writef("%d-%02d-%02d %02d:%02d:%02d.%03d ", tm.year, tm.month, tm.day, tm.hour, tm.minute, tm.second, msecs);
 
 				if (msg.threadName.length) dst.put(msg.threadName);

--- a/source/vibe/core/sync.d
+++ b/source/vibe/core/sync.d
@@ -840,7 +840,7 @@ struct LocalManualEvent {
 		}
 	}
 
-	bool opCast() const nothrow { return m_waiter !is null; }
+	bool opCast (T : bool) () const nothrow { return m_waiter !is null; }
 
 	/// A counter that is increased with every emit() call
 	int emitCount() const nothrow { return m_waiter.m_emitCount; }
@@ -1041,7 +1041,7 @@ struct ManualEvent {
 	}
 
 	deprecated("ManualEvent is always non-null!")
-	bool opCast() const shared nothrow { return true; }
+	bool opCast (T : bool) () const shared nothrow { return true; }
 
 	/// A counter that is increased with every emit() call
 	int emitCount() const shared nothrow @trusted { return atomicLoad(m_emitCount); }


### PR DESCRIPTION
I was going through the deprecated symbol and see the v2.069 comment, hence the first commit.
The second commit was found because we use `-checkaction=context`, which triggers the following error:
```
/Users/runner/hostedtoolcache/dc/ldc2-36198b36/x64/ldc2-36198b36-osx-x86_64/bin/../import/core/internal/dassert.d(194,36): Error: cannot implicitly convert expression `v.opCast()` of type `bool` to `const(ManualEvent)`
/Users/runner/hostedtoolcache/dc/ldc2-36198b36/x64/ldc2-36198b36-osx-x86_64/bin/../import/core/internal/dassert.d(449,30): Error: template instance `core.internal.dassert.miniFormat!(shared(ManualEvent))` error instantiating
/Users/runner/hostedtoolcache/dc/ldc2-36198b36/x64/ldc2-36198b36-osx-x86_64/bin/../import/core/internal/dassert.d(334,85):        instantiated from here: `formatMembers!(TaskFiber)`
/Users/runner/hostedtoolcache/dc/ldc2-36198b36/x64/ldc2-36198b36-osx-x86_64/bin/../import/core/internal/dassert.d(527,19):        3 recursive instantiations from here: `miniFormat!(const(TaskFiber)[])`
/Users/runner/hostedtoolcache/dc/ldc2-36198b36/x64/ldc2-36198b36-osx-x86_64/bin/../import/core/internal/dassert.d(75,49):        instantiated from here: `miniFormatFakeAttributes!(const(TaskFiber)[])`
submodules/vibe-core/source/vibe/internal/array.d(389,10):        instantiated from here: `_d_assert_fail!(TaskFiber[])`
submodules/vibe-core/source/vibe/core/core.d(1832,2):        instantiated from here: `FixedRingBuffer!(TaskFiber, 0LU, true)`
```