### PR TITLE
Changelog / version bump for v1.22.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+1.22.4 - 2022-05-26
+===================
+
+- Annotate `inout` functions with `return` (By Dennis Korpel) - [pull #313][issue313]
+- Better error message for GenericPath.fromTrustedString - [pull #314][issue314]
+
+[issue313]: https://github.com/vibe-d/vibe-core/issues/313
+[issue314]: https://github.com/vibe-d/vibe-core/issues/314
+
 1.22.3 - 2022-04-01
 ===================
 

--- a/source/vibe/core/core.d
+++ b/source/vibe/core/core.d
@@ -1458,7 +1458,7 @@ void setTaskCreationCallback(TaskCreationCallback func)
 /**
 	A version string representing the current vibe.d core version
 */
-enum vibeVersionString = "1.22.3";
+enum vibeVersionString = "1.22.4";
 
 
 /**


### PR DESCRIPTION
Will self merge in case the CI disagrees so that we get less spam while building Vibe.d.
There's still:
```
source/vibe/core/stream.d(168,29): Deprecation: scope variable `state` may not be thrown
```