### PR TITLE
Fix deprecation of throwing `state.readex`

### DIFF
--- a/source/vibe/core/stream.d
+++ b/source/vibe/core/stream.d
@@ -87,7 +87,6 @@ ulong pipe(InputStream, OutputStream)(InputStream source, OutputStream sink,
 					size_t[bufcount] bufferFill;
 					// buffer index that is being read/written
 					size_t read_idx = 0, write_idx = 0;
-                    Exception readex;
 					bool done = false;
 					LocalManualEvent evt;
 					size_t bytesWritten;


### PR DESCRIPTION
My attempt at solving the deprecation message (#316). Not entirely sure if this is the right way to go about it, but it seems like it works and passes all the unit tests.

Closes #316 