### PR TITLE
Fix almost all remaining scope related warnings

### DIFF
--- a/source/vibe/core/file.d
+++ b/source/vibe/core/file.d
@@ -732,7 +732,7 @@ struct FileStream {
 		//       be relied upon. For this reason, we MUST use the uninterruptible
 		//       version of asyncAwait here!
 		auto res = asyncAwaitUninterruptible!(FileIOCallback,
-			cb => eventDriver.files.read(m_fd, ctx.ptr, dst, mode, cb)
+			cb => eventDriver.files.read(m_fd, ctx.ptr, () @trusted { return dst; } (), mode, cb)
 		);
 		ctx.ptr += res[2];
 		enforce(res[1] == IOStatus.ok, "Failed to read data from disk.");

--- a/source/vibe/core/file.d
+++ b/source/vibe/core/file.d
@@ -745,13 +745,13 @@ struct FileStream {
 		assert(ret == dst.length, "File.read returned less data than requested for IOMode.all.");
 	}
 
-	size_t write(in ubyte[] bytes, IOMode mode)
+	size_t write(scope const(ubyte)[] bytes, IOMode mode)
 	{
 		// NOTE: cancelWrite is currently not behaving as specified and cannot
 		//       be relied upon. For this reason, we MUST use the uninterruptible
 		//       version of asyncAwait here!
 		auto res = asyncAwaitUninterruptible!(FileIOCallback,
-			cb => eventDriver.files.write(m_fd, ctx.ptr, bytes, mode, cb)
+			cb => eventDriver.files.write(m_fd, ctx.ptr, () @trusted { return bytes; } (), mode, cb)
 		);
 		ctx.ptr += res[2];
 		if (ctx.ptr > ctx.size) ctx.size = ctx.ptr;
@@ -759,12 +759,12 @@ struct FileStream {
 		return res[2];
 	}
 
-	void write(in ubyte[] bytes)
+	void write(scope const(ubyte)[] bytes)
 	{
 		write(bytes, IOMode.all);
 	}
 
-	void write(in char[] bytes)
+	void write(scope const(char)[] bytes)
 	{
 		write(cast(const(ubyte)[])bytes);
 	}

--- a/source/vibe/core/process.d
+++ b/source/vibe/core/process.d
@@ -95,7 +95,7 @@ Process spawnProcess(
 	scope string[] args,
 	const string[string] env = null,
 	Config config = Config.none,
-	scope NativePath workDir = NativePath.init)
+	NativePath workDir = NativePath.init)
 @trusted {
 	auto process = eventDriver.processes.spawn(
 		args,
@@ -114,10 +114,10 @@ Process spawnProcess(
 
 /// ditto
 Process spawnProcess(
-	scope string program,
+	string program,
 	const string[string] env = null,
 	Config config = Config.none,
-	scope NativePath workDir = NativePath.init)
+	NativePath workDir = NativePath.init)
 {
 	return spawnProcess(
 		[program],
@@ -129,11 +129,11 @@ Process spawnProcess(
 
 /// ditto
 Process spawnShell(
-	scope string command,
+	string command,
 	const string[string] env = null,
 	Config config = Config.none,
-	scope NativePath workDir = NativePath.init,
-	scope NativePath shellPath = nativeShell)
+	NativePath workDir = NativePath.init,
+	NativePath shellPath = nativeShell)
 {
 	return spawnProcess(
 		shellCommand(command, shellPath),
@@ -718,12 +718,12 @@ ProcessPipes pipeProcess(
 
 /// ditto
 ProcessPipes pipeShell(
-	scope string command,
+	string command,
 	Redirect redirect = Redirect.all,
 	const string[string] env = null,
 	Config config = Config.none,
-	scope NativePath workDir = NativePath.init,
-	scope NativePath shellPath = nativeShell)
+	NativePath workDir = NativePath.init,
+	NativePath shellPath = nativeShell)
 {
 	return pipeProcess(
 		shellCommand(command, nativeShell),
@@ -746,29 +746,29 @@ auto execute(
 	const string[string] env = null,
 	Config config = Config.none,
 	size_t maxOutput = size_t.max,
-	scope NativePath workDir = NativePath.init)
+	NativePath workDir = NativePath.init)
 @blocking {
 	return executeImpl!pipeProcess(args, env, config, maxOutput, workDir);
 }
 
 /// ditto
 auto execute(
-	scope string program,
+	string program,
 	const string[string] env = null,
 	Config config = Config.none,
 	size_t maxOutput = size_t.max,
-	scope NativePath workDir = NativePath.init)
+	NativePath workDir = NativePath.init)
 @blocking @trusted {
 	return executeImpl!pipeProcess(program, env, config, maxOutput, workDir);
 }
 
 /// ditto
 auto executeShell(
-	scope string command,
+	string command,
 	const string[string] env = null,
 	Config config = Config.none,
 	size_t maxOutput = size_t.max,
-	scope NativePath workDir = null,
+	NativePath workDir = null,
 	NativePath shellPath = nativeShell)
 @blocking {
 	return executeImpl!pipeShell(command, env, config, maxOutput, workDir, shellPath);
@@ -779,7 +779,7 @@ private auto executeImpl(alias spawn, Cmd, Args...)(
 	const string[string] env,
 	Config config,
 	size_t maxOutput,
-	scope NativePath workDir,
+	NativePath workDir,
 	Args args)
 @blocking {
 	Redirect redirect = Redirect.stdout;

--- a/source/vibe/core/process.d
+++ b/source/vibe/core/process.d
@@ -522,12 +522,12 @@ struct PipeOutputStream {
 
 	bool opCast(T)() const nothrow if (is(T == bool)) { return m_pipes != PipeFD.invalid; }
 
-	size_t write(in ubyte[] bytes, IOMode mode)
+	size_t write(scope const(ubyte)[] bytes, IOMode mode)
 	@blocking {
 		if (bytes.empty) return 0;
 
 		auto res = asyncAwait!(PipeIOCallback,
-			cb => eventDriver.pipes.write(m_pipe, bytes, mode, cb),
+			cb => eventDriver.pipes.write(m_pipe, () @trusted { return bytes; } (), mode, cb),
 			cb => eventDriver.pipes.cancelWrite(m_pipe));
 
 		switch (res[1]) {
@@ -540,8 +540,8 @@ struct PipeOutputStream {
 		return res[2];
 	}
 
-	void write(in ubyte[] bytes) @blocking { auto r = write(bytes, IOMode.all); assert(r == bytes.length); }
-	void write(in char[] bytes) @blocking { write(cast(const(ubyte)[])bytes); }
+	void write(scope const(ubyte)[] bytes) @blocking { auto r = write(bytes, IOMode.all); assert(r == bytes.length); }
+	void write(scope const(char)[] bytes) @blocking { write(cast(const(ubyte)[])bytes); }
 
 	void flush() {}
 	void finalize() {}

--- a/source/vibe/core/stream.d
+++ b/source/vibe/core/stream.d
@@ -296,6 +296,8 @@ interface InputStream {
 interface OutputStream {
 	@safe:
 
+	enum outputStreamVersion = 2;
+
 	/** Writes an array of bytes to the stream.
 	*/
 	size_t write(scope const(ubyte)[] bytes, IOMode mode) @blocking;

--- a/source/vibe/core/stream.d
+++ b/source/vibe/core/stream.d
@@ -298,11 +298,11 @@ interface OutputStream {
 
 	/** Writes an array of bytes to the stream.
 	*/
-	size_t write(in ubyte[] bytes, IOMode mode) @blocking;
+	size_t write(scope const(ubyte)[] bytes, IOMode mode) @blocking;
 	/// ditto
-	final void write(in ubyte[] bytes) @blocking { auto n = write(bytes, IOMode.all); assert(n == bytes.length); }
+	final void write(scope const(ubyte)[] bytes) @blocking { auto n = write(bytes, IOMode.all); assert(n == bytes.length); }
 	/// ditto
-	final void write(in char[] bytes) @blocking { write(cast(const(ubyte)[])bytes); }
+	final void write(scope const(char)[] bytes) @blocking { write(cast(const(ubyte)[])bytes); }
 
 	/** Flushes the stream and makes sure that all data is being written to the output device.
 	*/
@@ -427,7 +427,7 @@ interface ClosableRandomAccessStream : TruncatableStream {
 	the output of a particular stream is not needed but the stream needs to be drained.
 */
 final class NullOutputStream : OutputStream {
-	size_t write(in ubyte[] bytes, IOMode) { return bytes.length; }
+	size_t write(scope const(ubyte)[] bytes, IOMode) { return bytes.length; }
 	alias write = OutputStream.write;
 	void flush() {}
 	void finalize() {}

--- a/source/vibe/internal/async.d
+++ b/source/vibe/internal/async.d
@@ -138,15 +138,15 @@ void asyncAwaitAny(bool interruptible, Waitables...)(string func = __FUNCTION__)
 				};
 
 				debug(VibeAsyncLog) logDebugV("Starting operation %%s", %1$s);
-				alias WR%1$s = typeof(Waitables[%1$s].wait(callback_%1$s));
-				static if (is(WR%1$s == void)) Waitables[%1$s].wait(callback_%1$s);
-				else auto wr%1$s = Waitables[%1$s].wait(callback_%1$s);
+				alias WR%1$s = typeof(Waitables[%1$s].wait(() @trusted { return callback_%1$s; } ()));
+				static if (is(WR%1$s == void)) Waitables[%1$s].wait(() @trusted { return callback_%1$s; } ());
+				else auto wr%1$s = Waitables[%1$s].wait(() @trusted { return callback_%1$s; } ());
 
 				scope (exit) {
 					if (!fired[%1$s]) {
 						debug(VibeAsyncLog) logDebugV("Cancelling operation %%s", %1$s);
-						static if (is(WR%1$s == void)) Waitables[%1$s].cancel(callback_%1$s);
-						else Waitables[%1$s].cancel(callback_%1$s, wr%1$s);
+						static if (is(WR%1$s == void)) Waitables[%1$s].cancel(() @trusted { return callback_%1$s; } ());
+						else Waitables[%1$s].cancel(() @trusted { return callback_%1$s; } (), wr%1$s);
 						any_fired = true;
 						fired[%1$s] = true;
 					}

--- a/source/vibe/internal/traits.d
+++ b/source/vibe/internal/traits.d
@@ -473,14 +473,14 @@ unittest {
 
 	interface OutputStream {
 		@safe:
-		void write(in ubyte[] bytes);
+		void write(scope const(ubyte)[] bytes);
 		void flush();
 		void finalize();
 		void write(InputStream stream, ulong nbytes = 0);
 	}
 
 	static class OSClass : OutputStream {
-		override void write(in ubyte[] bytes) {}
+		override void write(scope const(ubyte)[] bytes) {}
 		override void flush() {}
 		override void finalize() {}
 		override void write(InputStream stream, ulong nbytes) {}
@@ -490,7 +490,7 @@ unittest {
 
 	static struct OSStruct {
 		@safe:
-		void write(in ubyte[] bytes) {}
+		void write(scope const(ubyte)[] bytes) {}
 		void flush() {}
 		void finalize() {}
 		void write(IS)(IS stream, ulong nbytes) {}
@@ -500,7 +500,7 @@ unittest {
 
 	static struct NonOSStruct {
 		@safe:
-		void write(in ubyte[] bytes) {}
+		void write(scope const(ubyte)[] bytes) {}
 		void flush(bool) {}
 		void finalize() {}
 		void write(InputStream stream, ulong nbytes) {}
@@ -530,7 +530,7 @@ unittest {
 		"`vibe.internal.traits.__unittest.NonOSStruct` does not implement method `flush` of type `@safe void()` from `vibe.internal.traits.__unittest.OutputStream`");
 
 	static struct NonOSStruct2 {
-		void write(in ubyte[] bytes) {} // not @safe
+		void write(scope const(ubyte)[] bytes) {} // not @safe
 		void flush(bool) {}
 		void finalize() {}
 		void write(InputStream stream, ulong nbytes) {}
@@ -540,7 +540,7 @@ unittest {
     // With dlang/dmd#11474 it shows up as `in`.
     // Remove when support for v2.093.0 is dropped
     static if (removeUnittestLineNumbers(checkInterfaceConformance!(NonOSStruct2, OutputStream)) !=
-        "`vibe.internal.traits.__unittest.NonOSStruct2` does not implement method `write` of type `@safe void(in ubyte[] bytes)` from `vibe.internal.traits.__unittest.OutputStream`")
+        "`vibe.internal.traits.__unittest.NonOSStruct2` does not implement method `write` of type `@safe void(scope const(ubyte)[] bytes)` from `vibe.internal.traits.__unittest.OutputStream`")
     {
         // Fallback to pre-2.092+
         static assert(removeUnittestLineNumbers(checkInterfaceConformance!(NonOSStruct2, OutputStream)) ==

--- a/tests/vibe.core.stream.pipe.d
+++ b/tests/vibe.core.stream.pipe.d
@@ -179,8 +179,8 @@ struct TestOutputStream {
 		}
 		return bytes.length;
 	}
-	void write(in ubyte[] bytes) @blocking { auto n = write(bytes, IOMode.all); assert(n == bytes.length); }
-	void write(in char[] bytes) @blocking { write(cast(const(ubyte)[])bytes); }
+	void write(scope const(ubyte)[] bytes) @blocking { auto n = write(bytes, IOMode.all); assert(n == bytes.length); }
+	void write(scope const(char)[] bytes) @blocking { write(cast(const(ubyte)[])bytes); }
 }
 
 mixin validateOutputStream!TestOutputStream;


### PR DESCRIPTION
Still has one warning that complains about passing a `scope` inferred argument to `runWorkerTask`. The cause seems to be the same as for #316, namely, all members of the passed struct value are also treated as if they had a `scope` in front of them. Since there is a class reference contained inside the struct, the memory of the class instance is suddenly also treated as `scope`.

**This PR contains breaking changes in `OutputStream` and `vibe.core.process`, which will require bumping to 2.0.0 for the next release**