### PR TITLE
Remove all task functions that take a throwing callback.

### DIFF
--- a/source/vibe/core/core.d
+++ b/source/vibe/core/core.d
@@ -337,25 +337,6 @@ Task runTask(CALLABLE, ARGS...)(CALLABLE task, auto ref ARGS args)
 	return runTask_internal!((ref tfi) { tfi.set(task, args); });
 }
 /// ditto
-deprecated("The `task` argument should be nothrow")
-Task runTask(ARGS...)(void delegate(ARGS) @safe task, auto ref ARGS args)
-{
-	return runTask_internal!((ref tfi) { tfi.set(task, args); });
-}
-/// ditto
-deprecated("The `task` argument should be nothrow")
-Task runTask(ARGS...)(void delegate(ARGS) @system task, auto ref ARGS args)
-@system {
-	return runTask_internal!((ref tfi) { tfi.set(task, args); });
-}
-/// ditto
-deprecated("The `task` argument should be nothrow")
-Task runTask(CALLABLE, ARGS...)(CALLABLE task, auto ref ARGS args)
-	if (!is(CALLABLE : void delegate(ARGS)) && isCallable!(CALLABLE, ARGS) && !isNothrowCallable!(CALLABLE, ARGS))
-{
-	return runTask_internal!((ref tfi) { tfi.set(task, args); });
-}
-/// ditto
 Task runTask(ARGS...)(TaskSettings settings, void delegate(ARGS) @safe nothrow task, auto ref ARGS args)
 {
 	return runTask_internal!((ref tfi) {
@@ -380,35 +361,6 @@ Task runTask(CALLABLE, ARGS...)(TaskSettings settings, CALLABLE task, auto ref A
 		tfi.set(task, args);
 	});
 }
-/// ditto
-deprecated("The `task` argument should be nothrow")
-Task runTask(ARGS...)(TaskSettings settings, void delegate(ARGS) @safe task, auto ref ARGS args)
-{
-	return runTask_internal!((ref tfi) {
-		tfi.settings = settings;
-		tfi.set(task, args);
-	});
-}
-/// ditto
-deprecated("The `task` argument should be nothrow")
-Task runTask(ARGS...)(TaskSettings settings, void delegate(ARGS) @system task, auto ref ARGS args)
-@system {
-	return runTask_internal!((ref tfi) {
-		tfi.settings = settings;
-		tfi.set(task, args);
-	});
-}
-/// ditto
-deprecated("The `task` argument should be nothrow")
-Task runTask(CALLABLE, ARGS...)(TaskSettings settings, CALLABLE task, auto ref ARGS args)
-	if (!is(CALLABLE : void delegate(ARGS)) && isCallable!(CALLABLE, ARGS) && !isNothrowCallable!(CALLABLE, ARGS))
-{
-	return runTask_internal!((ref tfi) {
-		tfi.settings = settings;
-		tfi.set(task, args);
-	});
-}
-
 
 unittest { // test proportional priority scheduling
 	auto tm = setTimer(1000.msecs, { assert(false, "Test timeout"); });
@@ -540,38 +492,6 @@ void runWorkerTask(alias method, T, ARGS...)(TaskSettings settings, shared(T) ob
 	setupWorkerThreads();
 	st_workerPool.runTask!method(settings, object, args);
 }
-/// ditto
-deprecated("The `func` argument should be nothrow")
-void runWorkerTask(FT, ARGS...)(FT func, auto ref ARGS args)
-	if (isFunctionPointer!FT && isCallable!(FT, ARGS) && !isNothrowCallable!(FT, ARGS))
-{
-	setupWorkerThreads();
-	st_workerPool.runTask(func, args);
-}
-/// ditto
-deprecated("The `method` argument should be nothrow")
-void runWorkerTask(alias method, T, ARGS...)(shared(T) object, auto ref ARGS args)
-	if (isMethod!(shared(T), method, ARGS) && !isNothrowMethod!(shared(T), method, ARGS))
-{
-	setupWorkerThreads();
-	st_workerPool.runTask!method(object, args);
-}
-/// ditto
-deprecated("The `func` argument should be nothrow")
-void runWorkerTask(FT, ARGS...)(TaskSettings settings, FT func, auto ref ARGS args)
-	if (isFunctionPointer!FT && isCallable!(FT, ARGS) && !isNothrowCallable!(FT, ARGS))
-{
-	setupWorkerThreads();
-	st_workerPool.runTask(settings, func, args);
-}
-/// ditto
-deprecated("The `method` argument should be nothrow")
-void runWorkerTask(alias method, T, ARGS...)(TaskSettings settings, shared(T) object, auto ref ARGS args)
-	if (isMethod!(shared(T), method, ARGS) && !isNothrowMethod!(shared(T), method, ARGS))
-{
-	setupWorkerThreads();
-	st_workerPool.runTask!method(settings, object, args);
-}
 
 
 /**
@@ -606,38 +526,6 @@ Task runWorkerTaskH(FT, ARGS...)(TaskSettings settings, FT func, auto ref ARGS a
 /// ditto
 Task runWorkerTaskH(alias method, T, ARGS...)(TaskSettings settings, shared(T) object, auto ref ARGS args)
 	if (isNothrowMethod!(shared(T), method, ARGS))
-{
-	setupWorkerThreads();
-	return st_workerPool.runTaskH!method(settings, object, args);
-}
-/// ditto
-deprecated("The `func` argument should be nothrow")
-Task runWorkerTaskH(FT, ARGS...)(FT func, auto ref ARGS args)
-	if (isFunctionPointer!FT && isCallable!(FT, ARGS) && !isNothrowCallable!(FT, ARGS))
-{
-	setupWorkerThreads();
-	return st_workerPool.runTaskH(func, args);
-}
-/// ditto
-deprecated("The `method` argument should be nothrow")
-Task runWorkerTaskH(alias method, T, ARGS...)(shared(T) object, auto ref ARGS args)
-	if (isMethod!(shared(T), method, ARGS) && !isNothrowMethod!(shared(T), method, ARGS))
-{
-	setupWorkerThreads();
-	return st_workerPool.runTaskH!method(object, args);
-}
-/// ditto
-deprecated("The `func` argument should be nothrow")
-Task runWorkerTaskH(FT, ARGS...)(TaskSettings settings, FT func, auto ref ARGS args)
-	if (isFunctionPointer!FT && isCallable!(FT, ARGS) && !isNothrowCallable!(FT, ARGS))
-{
-	setupWorkerThreads();
-	return st_workerPool.runTaskH(settings, func, args);
-}
-/// ditto
-deprecated("The `method` argument should be nothrow")
-Task runWorkerTaskH(alias method, T, ARGS...)(TaskSettings settings, shared(T) object, auto ref ARGS args)
-	if (isMethod!(shared(T), method, ARGS) && !isNothrowMethod!(shared(T), method, ARGS))
 {
 	setupWorkerThreads();
 	return st_workerPool.runTaskH!method(settings, object, args);
@@ -800,38 +688,6 @@ void runWorkerTaskDist(alias method, T, ARGS...)(TaskSettings settings, shared(T
 	setupWorkerThreads();
 	return st_workerPool.runTaskDist!method(settings, object, args);
 }
-/// ditto
-deprecated("The `func` argument should be nothrow")
-void runWorkerTaskDist(FT, ARGS...)(FT func, auto ref ARGS args)
-	if (isFunctionPointer!FT && isCallable!(FT, ARGS) && !isNothrowCallable!(FT, ARGS))
-{
-	setupWorkerThreads();
-	return st_workerPool.runTaskDist(func, args);
-}
-/// ditto
-deprecated("The `method` argument should be nothrow")
-void runWorkerTaskDist(alias method, T, ARGS...)(shared(T) object, ARGS args)
-	if (isMethod!(shared(T), method, ARGS) && !isNothrowMethod!(shared(T), method, ARGS))
-{
-	setupWorkerThreads();
-	return st_workerPool.runTaskDist!method(object, args);
-}
-/// ditto
-deprecated("The `func` argument should be nothrow")
-void runWorkerTaskDist(FT, ARGS...)(TaskSettings settings, FT func, auto ref ARGS args)
-	if (isFunctionPointer!FT && isCallable!(FT, ARGS) && !isNothrowCallable!(FT, ARGS))
-{
-	setupWorkerThreads();
-	return st_workerPool.runTaskDist(settings, func, args);
-}
-/// ditto
-deprecated("The `method` argument should be nothrow")
-void runWorkerTaskDist(alias method, T, ARGS...)(TaskSettings settings, shared(T) object, ARGS args)
-	if (isMethod!(shared(T), method, ARGS) && !isNothrowMethod!(shared(T), method, ARGS))
-{
-	setupWorkerThreads();
-	return st_workerPool.runTaskDist!method(settings, object, args);
-}
 
 
 /** Runs a new asynchronous task in all worker threads and returns the handles.
@@ -850,22 +706,6 @@ void runWorkerTaskDistH(HCB, FT, ARGS...)(scope HCB on_handle, FT func, auto ref
 /// ditto
 void runWorkerTaskDistH(HCB, FT, ARGS...)(TaskSettings settings, scope HCB on_handle, FT func, auto ref ARGS args)
 	if (isFunctionPointer!FT && isNothrowCallable!(FT, ARGS))
-{
-	setupWorkerThreads();
-	st_workerPool.runTaskDistH(settings, on_handle, func, args);
-}
-/// ditto
-deprecated("The `func` argument should be nothrow")
-void runWorkerTaskDistH(HCB, FT, ARGS...)(scope HCB on_handle, FT func, auto ref ARGS args)
-	if (isFunctionPointer!FT && isCallable!(FT, ARGS) && !isNothrowCallable!(FT, ARGS))
-{
-	setupWorkerThreads();
-	st_workerPool.runTaskDistH(on_handle, func, args);
-}
-/// ditto
-deprecated("The `func` argument should be nothrow")
-void runWorkerTaskDistH(HCB, FT, ARGS...)(TaskSettings settings, scope HCB on_handle, FT func, auto ref ARGS args)
-	if (isFunctionPointer!FT && isCallable!(FT, ARGS) && !isNothrowCallable!(FT, ARGS))
 {
 	setupWorkerThreads();
 	st_workerPool.runTaskDistH(settings, on_handle, func, args);

--- a/source/vibe/core/taskpool.d
+++ b/source/vibe/core/taskpool.d
@@ -191,54 +191,6 @@ shared final class TaskPool {
 		}
 		return runTaskH(settings, &wrapper!(), object, args);
 	}
-	/// ditto
-	deprecated("The `func` argument should be `nothrow`.")
-	Task runTaskH(FT, ARGS...)(FT func, auto ref ARGS args)
-		if (isFunctionPointer!FT && isCallable!(FT, ARGS) && !isNothrowCallable!(FT, ARGS))
-	{
-		foreach (T; ARGS) static assert(isWeaklyIsolated!T, "Argument type "~T.stringof~" is not safe to pass between threads.");
-
-		// workaround for runWorkerTaskH to work when called outside of a task
-		if (Task.getThis() == Task.init) {
-			Task ret;
-			.runTask({ ret = doRunTaskH(TaskSettings.init, func, args); }).join();
-			return ret;
-		} else return doRunTaskH(TaskSettings.init, func, args);
-	}
-	/// ditto
-	deprecated("The `method` argument should be `nothrow`.")
-	Task runTaskH(alias method, T, ARGS...)(shared(T) object, auto ref ARGS args)
-		if (isMethod!(shared(T), method, ARGS) && !isNothrowMethod!(shared(T), method, ARGS))
-	{
-		static void wrapper()(shared(T) object, ref ARGS args) {
-			__traits(getMember, object, __traits(identifier, method))(args);
-		}
-		return runTaskH(&wrapper!(), object, args);
-	}
-	/// ditto
-	deprecated("The `func` argument should be `nothrow`.")
-	Task runTaskH(FT, ARGS...)(TaskSettings settings, FT func, auto ref ARGS args)
-		if (isFunctionPointer!FT && isCallable!(FT, ARGS) && !isNothrowCallable!(FT, ARGS))
-	{
-		foreach (T; ARGS) static assert(isWeaklyIsolated!T, "Argument type "~T.stringof~" is not safe to pass between threads.");
-
-		// workaround for runWorkerTaskH to work when called outside of a task
-		if (Task.getThis() == Task.init) {
-			Task ret;
-			.runTask({ ret = doRunTaskH(settings, func, args); }).join();
-			return ret;
-		} else return doRunTaskH(settings, func, args);
-	}
-	/// ditto
-	deprecated("The `method` argument should be `nothrow`.")
-	Task runTaskH(alias method, T, ARGS...)(TaskSettings settings, shared(T) object, auto ref ARGS args)
-		if (isMethod!(shared(T), method, ARGS) && !isNothrowMethod!(shared(T), method, ARGS))
-	{
-		static void wrapper()(shared(T) object, ref ARGS args) {
-			__traits(getMember, object, __traits(identifier, method))(args);
-		}
-		return runTaskH(settings, &wrapper!(), object, args);
-	}
 
 	// NOTE: needs to be a separate function to avoid recursion for the
 	//       workaround above, which breaks @safe inference
@@ -303,42 +255,6 @@ shared final class TaskPool {
 	/// ditto
 	void runTaskDist(alias method, T, ARGS...)(TaskSettings settings, shared(T) object, auto ref ARGS args)
 		if (isNothrowMethod!(shared(T), method, ARGS))
-	{
-		auto func = &__traits(getMember, object, __traits(identifier, method));
-		foreach (T; ARGS) static assert(isWeaklyIsolated!T, "Argument type "~T.stringof~" is not safe to pass between threads.");
-
-		runTaskDist_unsafe(settings, func, args);
-	}
-	/// ditto
-	deprecated("The `func` argument should be `nothrow`.")
-	void runTaskDist(FT, ARGS...)(FT func, auto ref ARGS args)
-		if (isFunctionPointer!FT && isCallable!(FT, ARGS) && !isNothrowCallable!(FT, ARGS))
-	{
-		foreach (T; ARGS) static assert(isWeaklyIsolated!T, "Argument type "~T.stringof~" is not safe to pass between threads.");
-		runTaskDist_unsafe(TaskSettings.init, func, args);
-	}
-	/// ditto
-	deprecated("The `method` argument should be `nothrow`.")
-	void runTaskDist(alias method, T, ARGS...)(shared(T) object, auto ref ARGS args)
-		if (isMethod!(shared(T), method, ARGS) && !isNothrowMethod!(shared(T), method, ARGS))
-	{
-		auto func = &__traits(getMember, object, __traits(identifier, method));
-		foreach (T; ARGS) static assert(isWeaklyIsolated!T, "Argument type "~T.stringof~" is not safe to pass between threads.");
-
-		runTaskDist_unsafe(TaskSettings.init, func, args);
-	}
-	/// ditto
-	deprecated("The `func` argument should be `nothrow`.")
-	void runTaskDist(FT, ARGS...)(TaskSettings settings, FT func, auto ref ARGS args)
-		if (isFunctionPointer!FT && isCallable!(FT, ARGS) && !isNothrowCallable!(FT, ARGS))
-	{
-		foreach (T; ARGS) static assert(isWeaklyIsolated!T, "Argument type "~T.stringof~" is not safe to pass between threads.");
-		runTaskDist_unsafe(settings, func, args);
-	}
-	/// ditto
-	deprecated("The `method` argument should be `nothrow`.")
-	void runTaskDist(alias method, T, ARGS...)(TaskSettings settings, shared(T) object, auto ref ARGS args)
-		if (isMethod!(shared(T), method, ARGS) && !isNothrowMethod!(shared(T), method, ARGS))
 	{
 		auto func = &__traits(getMember, object, __traits(identifier, method));
 		foreach (T; ARGS) static assert(isWeaklyIsolated!T, "Argument type "~T.stringof~" is not safe to pass between threads.");

--- a/tests/0-tcp.d
+++ b/tests/0-tcp.d
@@ -144,18 +144,10 @@ void test2()
 	lt.join();
 }
 
-void test()
+void main()
 {
 	test1();
 	test2();
-	exitEventLoop();
-}
-
-void main()
-{
-	import std.functional : toDelegate;
-	runTask(toDelegate(&test));
-	runEventLoop();
 }
 
 string readLine(TCPConnection c) @safe

--- a/tests/0-tcpproxy.d
+++ b/tests/0-tcpproxy.d
@@ -75,7 +75,8 @@ void runTest()
 			auto server = connectTCP(l1.bindAddress);
 
 			// pipe server to client as long as the server connection is alive
-			auto t = runTask!(TCPConnection, TCPConnection)((client, server) {
+			auto t = runTask!(TCPConnection, TCPConnection)((client, server) nothrow {
+					scope (failure) assert(false);
 					scope (exit) client.close();
 					pipe(server, client);
 					logInfo("Proxy 2 out");
@@ -106,18 +107,9 @@ void runTest()
 	testProtocol(connectTCP(l2.bindAddress), true);
 }
 
-int main()
+void main()
 {
-	int ret = 0;
-	runTask({
-		try runTest();
-		catch (Throwable th) {
-			th.logException("Test failed");
-			ret = 1;
-		} finally exitEventLoop(true);
-	});
-	runEventLoop();
-	return ret;
+	runTest();
 }
 
 string readLine(TCPConnection c) @safe

--- a/tests/issue-161-multiple-joiners.d
+++ b/tests/issue-161-multiple-joiners.d
@@ -19,8 +19,9 @@ void main()
 	Task t;
 
 	runTask({
-		t = runTask({ sleep(100.msecs); });
-		t.join();
+		t = runTask({ try sleep(100.msecs); catch (Exception e) assert(false, e.msg); });
+		try t.join();
+		catch (Exception e) assert(false, e.msg);
 	});
 
 	// let the outer task run and start the inner task

--- a/tests/issue-267-pipe.d
+++ b/tests/issue-267-pipe.d
@@ -14,7 +14,7 @@ void main()
 		auto p = pipe();
 		runTask(()
 		{
-			sleep(10.msecs);
+			sleepUninterruptible(10.msecs);
 			exitEventLoop();
 		});
 		runEventLoop();

--- a/tests/issue-66-yield-eventloop-exit.d
+++ b/tests/issue-66-yield-eventloop-exit.d
@@ -10,7 +10,8 @@ void main()
 {
 	bool visited = false;
 	runTask({
-		yield();
+		try yield();
+		catch (Exception e) assert(false, e.msg);
 		visited = true;
 		exitEventLoop();
 	});

--- a/tests/std.concurrency.d
+++ b/tests/std.concurrency.d
@@ -103,8 +103,9 @@ void main()
 // corrects for small timing inaccuracies to avoid the counter
 // getting systematically out of sync when sleep timing is inaccurate
 void sleepUntil(Duration until, MonoTime start_time, Duration min_sleep)
-{
+nothrow {
 	auto tm = MonoTime.currTime;
 	auto timeout = max(start_time - tm + until, min_sleep);
-	sleep(timeout);
+	try sleep(timeout);
+	catch (Exception e) assert(false, e.msg);
 }

--- a/tests/vibe.core.concurrency.1408.d
+++ b/tests/vibe.core.concurrency.1408.d
@@ -13,8 +13,11 @@ import core.time : msecs;
 import std.functional : toDelegate;
 
 void test()
-{
+nothrow {
+	scope (failure) assert(false);
+
 	auto t = runTask({
+		scope (failure) assert(false);
 		bool gotit;
 		receive((int i) { assert(i == 10); gotit = true; });
 		assert(gotit);
@@ -27,6 +30,7 @@ void test()
 
 	// ensure that recycled fibers will get a clean message queue
 	auto t2 = runTask({
+		scope (failure) assert(false);
 		bool gotit;
 		receive((int i) { assert(i == 12); gotit = true; });
 		assert(gotit);
@@ -36,6 +40,7 @@ void test()
 
 	// test worker tasks
 	auto t3 = runWorkerTaskH({
+		scope (failure) assert(false);
 		bool gotit;
 		receive((int i) { assert(i == 13); gotit = true; });
 		assert(gotit);

--- a/tests/vibe.core.core.1590.d
+++ b/tests/vibe.core.core.1590.d
@@ -19,11 +19,14 @@ class Conn {}
 void main()
 {
     runTask({
+    	scope (failure) assert(false);
+
         // create pool with 2 max connections
         bool[int] results;
         auto pool = new ConnectionPool!Conn({ return new Conn; }, 2);
         auto task = Task.getThis(); // main task
-        void worker(int id) {
+        void worker(int id) nothrow {
+        	scope (failure) assert(false);
             {
                 auto conn = pool.lockConnection(); // <-- worker(4) hangs here
                 sleep(1.msecs); // <-- important, without sleep everything works fine

--- a/tests/vibe.core.core.1742.d
+++ b/tests/vibe.core.core.1742.d
@@ -29,6 +29,8 @@ void main()
 	assert(g.empty);
 
 	runTask({
+		scope (failure) assert(false);
+
 		auto g2 = new Generator!int({
 			auto t = runTask({});
 			t.join();

--- a/tests/vibe.core.core.refcount.d
+++ b/tests/vibe.core.core.refcount.d
@@ -9,17 +9,19 @@ import std.stdio;
 
 struct RC {
 	int* rc;
-	this(int* rc) { this.rc = rc; }
-	this(this) {
+	this(int* rc) nothrow { this.rc = rc; }
+	this(this) nothrow {
 		if (rc) {
 			(*rc)++;
-			writefln("addref %s", *rc);
+			try writefln("addref %s", *rc);
+			catch (Exception e) assert(false, e.msg);
 		}
 	}
-	~this() {
+	~this() nothrow {
 		if (rc) {
 			(*rc)--;
-			writefln("release %s", *rc);
+			try writefln("release %s", *rc);
+			catch (Exception e) assert(false, e.msg);
 		}
 	}
 }
@@ -32,7 +34,7 @@ void main()
 	{
 		auto s = RC(&rc);
 		assert(rc == 1);
-		runTask((RC st) {
+		runTask((RC st) nothrow {
 			assert(rc == 2);
 			st = RC.init;
 			assert(rc == 1);

--- a/tests/vibe.core.net.1376.d
+++ b/tests/vibe.core.net.1376.d
@@ -39,7 +39,9 @@ void main()
 			conn.close();
 		} catch (Exception e) assert(false, e.msg);
 
-		sleep(50.msecs);
+		try sleep(50.msecs);
+		catch (Exception e) assert(false, e.msg);
+
 		exitEventLoop();
 	});
 

--- a/tests/vibe.core.net.1429.d
+++ b/tests/vibe.core.net.1429.d
@@ -15,7 +15,7 @@ void main()
 	auto udp = listenUDP(11429, "127.0.0.1");
 
 	runTask({
-		sleep(500.msecs);
+		sleepUninterruptible(500.msecs);
 		assert(false, "Receive call did not return in a timely manner. Killing process.");
 	});
 

--- a/tests/vibe.core.net.1441.d
+++ b/tests/vibe.core.net.1441.d
@@ -25,6 +25,8 @@ void main()
 	});
 
 	runTask({
+		scope (failure) assert(false);
+
 		auto conn = connectTCP("127.0.0.1", 11375);
 		conn.close();
 

--- a/tests/vibe.core.net.1726.d
+++ b/tests/vibe.core.net.1726.d
@@ -28,7 +28,8 @@ void performTest(bool reverse)
 			} // expected
 		}, conn);
 		auto wt = runTask!TCPConnection((conn) {
-			sleep(reverse ? 100.msecs : 20.msecs); // give the connection time to establish
+			try sleep(reverse ? 100.msecs : 20.msecs); // give the connection time to establish
+			catch (Exception e) assert(false, e.msg);
 			try {
 				// write enough to let the connection block long enough to let
 				// the remote end close the connection

--- a/tests/vibe.core.process.d
+++ b/tests/vibe.core.process.d
@@ -33,7 +33,8 @@ void testCat()
 
 	string output;
 	auto outputTask = runTask({
-		output = procPipes.stdout.collectOutput();
+		try output = procPipes.stdout.collectOutput();
+		catch (Exception e) assert(false, e.msg);
 	});
 
 	auto inputs = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"]
@@ -64,7 +65,8 @@ void testStderr()
 
 	string output;
 	auto outputTask = runTask({
-		output = procPipes.stderr.collectOutput();
+		try output = procPipes.stderr.collectOutput();
+		catch (Exception e) assert(false, e.msg);
 	});
 
 	auto inputs = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"]
@@ -131,7 +133,8 @@ void testIgnoreSigterm()
 
 	string output;
 	auto outputTask = runTask({
-		output = procPipes.stdout.collectOutput();
+		try output = procPipes.stdout.collectOutput();
+		catch (Exception e) assert(false, e.msg);
 	});
 
 	assert(!procPipes.process.exited);


### PR DESCRIPTION
All uncaught exceptions in task callbacks haven't been handled since a long time. This removes the compatibility overloads and only keeps the ones enforcing nothrow.