### PR TITLE
Fix TCP double release crash for concurrent close and read

### DIFF
--- a/tests/0-tcp.d
+++ b/tests/0-tcp.d
@@ -112,7 +112,7 @@ void test1()
 void test2()
 {
 	Task lt;
-	logInfo("Perform test \"disconnect with pending data\"");
+	logInfo("Perform test \"disconnect with pending write data\"");
 	auto l = listenTCP(0, (conn) @safe nothrow {
 		try {
 			lt = Task.getThis();
@@ -144,10 +144,43 @@ void test2()
 	lt.join();
 }
 
+void test3()
+{
+	Task lt;
+	logInfo("Perform test \"disconnect with pending read data\"");
+	auto l = listenTCP(0, (conn) @safe nothrow {
+		try {
+			lt = Task.getThis();
+			sleep(1.seconds);
+			conn.close();
+			conn = TCPConnection.init;
+		} catch (Exception e) {
+			assert(false, e.msg);
+		}
+	}, "127.0.0.1");
+	scope (exit) l.stopListening;
+
+	ubyte[256] buf;
+	auto conn = connectTCP(l.bindAddress);
+	conn.readTimeout = 10.msecs;
+	try {
+		conn.read(buf);
+		assert(false);
+	} catch (Exception e) {}
+	conn.close();
+	conn = TCPConnection.init;
+
+	sleep(100.msecs);
+
+	assert(lt != Task.init);
+	lt.join();
+}
+
 void main()
 {
 	test1();
 	test2();
+	test3();
 }
 
 string readLine(TCPConnection c) @safe


### PR DESCRIPTION
The existing `releaseHandle()` method only reset the `m_socket` field if the release was the final one. This meant that calling `close()` during a pending read would leave the field set and thus cause another release from within the destructor. If that release came before the read operation was finished, this resulted in the underlying eventcode socket slot to be cleared before all operations had actually finished, consequently causing a crash in eventcore.