### PR TITLE
Deprecate GenericPath.Segment.

### DIFF
--- a/.github/workflows/musl.yml
+++ b/.github/workflows/musl.yml
@@ -3,10 +3,10 @@ name: Musl tests
 on:
   pull_request:
     branches:
-      - master
+      - 1.x.x
   push:
     branches:
-      - master
+      - 1.x.x
       - github_actions
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,10 +4,10 @@ name: Run all D Tests
 on:
   pull_request:
     branches:
-      - master
+      - 1.x.x
   push:
     branches:
-      - master
+      - 1.x.x
       - github_actions
 
 jobs:

--- a/source/vibe/core/path.d
+++ b/source/vibe/core/path.d
@@ -215,7 +215,9 @@ struct GenericPath(F) {
 
 	/** A single path segment.
 	*/
-	static struct Segment {
+	deprecated("Use .Segment2 instead.") alias Segment = SegmentOld;
+
+	private static struct SegmentOld {
 		@safe:
 
 		private {
@@ -257,13 +259,13 @@ struct GenericPath(F) {
 				name = The raw (unencoded) name of the path segment
 				separator = Optional trailing path separator (e.g. `'/'`)
 		*/
-		static Segment fromTrustedString(string name, char separator = '\0')
+		static SegmentOld fromTrustedString(string name, char separator = '\0')
 		nothrow @nogc pure {
 			import std.algorithm.searching : any;
 			assert(separator == '\0' || Format.isSeparator(separator));
 			assert(Format.validateDecodedSegment(name) is null, "Invalid path segment.");
 
-			Segment ret;
+			SegmentOld ret;
 			ret.m_name = name;
 			ret.m_separator = separator;
 			return ret;
@@ -301,30 +303,32 @@ struct GenericPath(F) {
 				A `PathValidationException` is thrown if the segment name cannot
 				be represented in the target path format.
 		*/
-		GenericPath!F.Segment opCast(T : GenericPath!F.Segment, F)()
+		GenericPath!F.SegmentOld opCast(T : GenericPath!F.SegmentOld, F)()
 		const {
 			char dsep = '\0';
 			if (m_separator) {
 				if (F.isSeparator(m_separator)) dsep = m_separator;
 				else dsep = F.defaultSeparator;
 			}
-			return GenericPath!F.Segment(m_name, dsep);
+			return GenericPath!F.SegmentOld(m_name, dsep);
 		}
 
 		/// Compares two path segment names
-		bool opEquals(Segment other) const nothrow @nogc { return this.name == other.name && this.hasSeparator == other.hasSeparator; }
+		bool opEquals(SegmentOld other) const nothrow @nogc { return this.name == other.name && this.hasSeparator == other.hasSeparator; }
 		/// ditto
 		bool opEquals(string name) const nothrow @nogc { return this.name == name; }
 	}
 
 	/** Represents a path as an forward range of `Segment`s.
 	*/
-	static struct PathRange {
+	deprecated alias PathRange = PathRangeOld;
+
+	private static  struct PathRangeOld {
 		import std.traits : ReturnType;
 
 		private {
 			string m_path;
-			Segment m_front;
+			SegmentOld m_front;
 		}
 
 		private this(string path)
@@ -333,22 +337,22 @@ struct GenericPath(F) {
 			if (m_path.length) {
 				auto ap = Format.getAbsolutePrefix(m_path);
 				if (ap.length && !Format.isSeparator(ap[0]))
-					m_front = Segment.fromTrustedString(null, Format.defaultSeparator);
+					m_front = SegmentOld.fromTrustedString(null, Format.defaultSeparator);
 				else readFront();
 			}
 		}
 
-		@property bool empty() const nothrow @nogc { return m_path.length == 0 && m_front == Segment.init; }
+		@property bool empty() const nothrow @nogc { return m_path.length == 0 && m_front == SegmentOld.init; }
 
-		@property PathRange save() { return this; }
+		@property PathRangeOld save() { return this; }
 
-		@property Segment front() { return m_front; }
+		@property SegmentOld front() { return m_front; }
 
 		void popFront()
 		nothrow {
-			assert(m_front != Segment.init);
+			assert(m_front != SegmentOld.init);
 			if (m_path.length) readFront();
-			else m_front = Segment.init;
+			else m_front = SegmentOld.init;
 		}
 
 		private void readFront()
@@ -367,8 +371,8 @@ struct GenericPath(F) {
 				string ndec = Format.decodeSingleSegment(n);
 			else
 				string ndec = Format.decodeSingleSegment(n).array;
-			m_front = Segment.fromTrustedString(ndec, sep);
-			assert(m_front != Segment.init);
+			m_front = SegmentOld.fromTrustedString(ndec, sep);
+			assert(m_front != SegmentOld.init);
 		}
 	}
 
@@ -575,7 +579,7 @@ struct GenericPath(F) {
 		This is equivalent to calling the range based constructor with a
 		single-element range.
 	*/
-	this(Segment segment)
+	this(SegmentOld segment)
 	{
 		import std.range : only;
 		this(only(segment));
@@ -594,7 +598,7 @@ struct GenericPath(F) {
 			throw an exception.
 	*/
 	this(R)(R segments)
-		if (isInputRange!R && is(ElementType!R : Segment))
+		if (isInputRange!R && is(ElementType!R : SegmentOld))
 	{
 		import std.array : appender;
 		auto dst = appender!string;
@@ -656,7 +660,7 @@ struct GenericPath(F) {
 	}
 
 	/// Iterates over the path by `Segment`.
-	@property PathRange bySegment() const { return PathRange(m_path); }
+	deprecated @property PathRange bySegment() const { return PathRange(m_path); }
 
 
 	/** Iterates over the individual segments of the path.
@@ -799,7 +803,7 @@ struct GenericPath(F) {
 
 
 	/// Returns the trailing segment of the path.
-	@property Segment head()
+	deprecated @property Segment head()
 	const {
 		import std.array : array;
 
@@ -980,11 +984,11 @@ struct GenericPath(F) {
 	*/
 	GenericPath opBinary(string op : "~")(string subpath) const { return this ~ GenericPath(subpath); }
 	/// ditto
-	GenericPath opBinary(string op : "~")(Segment subpath) const { return this ~ GenericPath(subpath); }
+	GenericPath opBinary(string op : "~")(SegmentOld subpath) const { return this ~ GenericPath(subpath); }
 	/// ditto
 	GenericPath opBinary(string op : "~")(Segment2 subpath) const { return this ~ GenericPath(subpath); }
 	/// ditto
-	GenericPath opBinary(string op : "~", F)(GenericPath!F.Segment subpath) const { return this ~ cast(Segment)(subpath); }
+	GenericPath opBinary(string op : "~", F)(GenericPath!F.SegmentOld subpath) const { return this ~ cast(Segment)(subpath); }
 	/// ditto
 	GenericPath opBinary(string op : "~", F)(GenericPath!F.Segment2 subpath) const { return this ~ cast(Segment2)(subpath); }
 	/// ditto
@@ -997,7 +1001,7 @@ struct GenericPath(F) {
 	GenericPath opBinary(string op : "~", F)(GenericPath!F subpath) const if (!is(F == Format)) { return this ~ cast(GenericPath)subpath; }
 	/// ditto
 	GenericPath opBinary(string op : "~", R)(R entries) const nothrow
-		if (isInputRange!R && is(ElementType!R : Segment))
+		if (isInputRange!R && is(ElementType!R : SegmentOld))
 	{
 		return this ~ GenericPath(entries);
 	}
@@ -1021,7 +1025,7 @@ struct GenericPath(F) {
 	}
 }
 
-unittest {
+deprecated unittest {
 	assert(PosixPath("hello/world").bySegment.equal([PosixPath.Segment("hello",'/'), PosixPath.Segment("world")]));
 	assert(PosixPath("/hello/world/").bySegment.equal([PosixPath.Segment("",'/'), PosixPath.Segment("hello",'/'), PosixPath.Segment("world",'/')]));
 	assert(PosixPath("hello\\world").bySegment.equal([PosixPath.Segment("hello\\world")]));
@@ -1045,7 +1049,7 @@ unittest {
 	assert(WindowsPath("C:\\Windows").byPrefix.equal([WindowsPath("C:\\"), WindowsPath("C:\\Windows")]));
 }
 
-unittest
+deprecated unittest
 {
 	{
 		auto unc = "\\\\server\\share\\path";
@@ -1092,7 +1096,10 @@ unittest
 		alias S = WindowsPath.Segment;
 		assert(winpathp.bySegment.equal([S("", '/'), S("C:", '\\'), S("windows", '\\'), S("test")]));
 	}
+}
 
+unittest
+{
 	{
 		auto dotpath = "/test/../test2/././x/y";
 		auto dotpathp = PosixPath(dotpath);
@@ -1124,10 +1131,7 @@ unittest
 	assert(PosixPath("") ~ NativePath("foo/bar") == PosixPath("foo/bar"));
 	assert(PosixPath("foo") ~ NativePath("bar") == PosixPath("foo/bar"));
 	assert(PosixPath("foo/") ~ NativePath("bar") == PosixPath("foo/bar"));
-}
 
-unittest
-{
 	{
 		auto unc = "\\\\server\\share\\path";
 		auto uncp = WindowsPath(unc);
@@ -1184,7 +1188,7 @@ unittest
 	//void test4(const(PosixPath)[] ps) { app.put(ps); }
 }
 
-unittest {
+deprecated unittest {
 	import std.exception : assertThrown, assertNotThrown;
 
 	assertThrown!PathValidationException(WindowsPath.Segment("foo/bar"));
@@ -2048,7 +2052,10 @@ unittest {
 	assert(!isAsciiAlphaNum(':'));
 }
 
-unittest { // regression tests
+deprecated unittest { // regression tests
 	assert(NativePath("").bySegment.empty);
+}
+
+unittest { // regression tests
 	assert(NativePath("").bySegment2.empty);
 }


### PR DESCRIPTION
This prepares the code for a full removal of GenericPath.Segment and is supposed to be included in the next 1.x.x release. In the 2.x.x branch, the removal will be completed and Segment2 will be renamed to Segment (keeping an alias for some backwards compatibility).

Note that this is a cherry pick from master (a460e7952a9358ae4b7c7a7447fd7af1b17a5164).