### PR TITLE
Fixed typo so that testing on server is not actually testing on proxy

### DIFF
--- a/tests/0-tcpproxy.d
+++ b/tests/0-tcpproxy.d
@@ -96,9 +96,9 @@ void runTest()
 
 	// test server
 	logInfo("Test protocol implementation on server");
-	testProtocol(connectTCP(l2.bindAddress), false);
+	testProtocol(connectTCP(l1.bindAddress), false);
 	logInfo("Test protocol implementation on server with forced disconnect");
-	testProtocol(connectTCP(l2.bindAddress), true);
+	testProtocol(connectTCP(l1.bindAddress), true);
 
 	// test proxy
 	logInfo("Test protocol implementation on proxy");


### PR DESCRIPTION
"Test protocol implementation on server with and without forced disconnect" referenced the proxy address (l2.bindAddress) and not the server address (l1.bindAddress). This has been changed.