### PR TITLE
Raise CI timeout from 15 to 30 minutes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ on:
 jobs:
     test:
         name: Dub Tests
-        timeout-minutes: 15
+        timeout-minutes: 30
         strategy:
             fail-fast: false
             matrix:


### PR DESCRIPTION
The latest LDC release makes us go over the limit on MacOS.