### PR TITLE
Ip transparent socket option

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -4,7 +4,9 @@ authors "Sönke Ludwig"
 copyright "Copyright © 2016-2020, Sönke Ludwig"
 license "MIT"
 
-dependency "eventcore" version="~>0.9.17"
+#dependency "eventcore" version="~>0.9.17"
+#dependency "eventcore" path="../eventcore"
+dependency "eventcore" version="~master"
 dependency "stdx-allocator" version="~>2.77.0"
 
 targetName "vibe_core"

--- a/dub.sdl
+++ b/dub.sdl
@@ -4,9 +4,7 @@ authors "Sönke Ludwig"
 copyright "Copyright © 2016-2020, Sönke Ludwig"
 license "MIT"
 
-#dependency "eventcore" version="~>0.9.17"
-#dependency "eventcore" path="../eventcore"
-dependency "eventcore" version="~master"
+dependency "eventcore" version="~>0.9.17"
 dependency "stdx-allocator" version="~>2.77.0"
 
 targetName "vibe_core"

--- a/source/vibe/core/net.d
+++ b/source/vibe/core/net.d
@@ -137,6 +137,10 @@ TCPListener listenTCP(ushort port, TCPConnectionDelegate connection_callback, st
 		sopts |= StreamListenOptions.reusePort;
 	else
 		sopts &= ~StreamListenOptions.reusePort;
+	if (options & TCPListenOptions.ipTransparent)
+		sopts |= StreamListenOptions.ipTransparent;
+	else
+		sopts &= ~StreamListenOptions.ipTransparent;
 	scope addrc = new RefAddress(addr.sockAddr, addr.sockAddrLen);
 	auto sock = eventDriver.sockets.listenStream(addrc, sopts,
 		(StreamListenSocketFD ls, StreamSocketFD s, scope RefAddress addr) @safe nothrow {
@@ -1173,6 +1177,8 @@ enum TCPListenOptions {
 	reusePort = 1<<2,
 	/// Enable address reuse
 	reuseAddress = 1<<3,
+	/// Enable IP transparent socket option
+	ipTransparent = 1<<4,
 	///
 	defaults = reuseAddress
 }


### PR DESCRIPTION
Add support for IP_TRANSPARENT socket options. Only Linux provides this option. Related to eventcore pull #218.