### PR TITLE
TcpConnect.read(buffer,IOMode.once) should throw ReadTimeoutException

### DIFF
--- a/examples/echo-server/dub.sdl
+++ b/examples/echo-server/dub.sdl
@@ -1,3 +1,11 @@
 name "echo-server"
 description "A simple echo protocol server implementation"
 dependency "vibe-core"  path="../../"
+configuration "default" {
+    targetType "executable"
+}
+configuration "no-pipe" {
+    targetType "executable"
+	versions "READ_WRITE"
+}
+

--- a/examples/echo-server/source/app.d
+++ b/examples/echo-server/source/app.d
@@ -1,20 +1,75 @@
 import vibe.core.core : runApplication;
 import vibe.core.log;
-import vibe.core.net : listenTCP;
+import vibe.core.net;
 import vibe.core.stream : pipe;
 
-void main()
+
+version(READ_WRITE)
 {
-	auto listeners = listenTCP(7000, (conn) @safe nothrow {
-			try pipe(conn, conn);
-			catch (Exception e)
-				logError("Error: %s", e.msg);
-	});
+	import std.exception;
+	import std.datetime;
+	import std.stdio;
+	
+	
+	
+	
+	scope const(ubyte[]) readTcpOnce(ref TCPConnection stream,scope ubyte[] dst){
+		ubyte[] ret = null;
+        collectException!ReadTimeoutException({
+			import eventcore.driver : IOMode;
+			auto len = stream.read(dst, IOMode.once);
+			if(len == 0)
+				return null;
+			else
+				return dst[0..len];
+        }(),ret);
+        return ret;
+	}
 
-	// closes the listening sockets
-	scope (exit)
-		foreach (l; listeners)
-			l.stopListening();
+	void handleTcp(ref TCPConnection stream) @trusted nothrow {
+		auto e = collectException({
+			stream.readTimeout = dur!"seconds"(30);
+			ubyte[] buffer = new ubyte[2048];
+			while(stream.connected){
+				auto tmp = stream.readTcpOnce(buffer);
+				if(tmp is null){
+					writefln("[%s] read time out!",
+        			Clock.currTime);
+				} else {
+					stream.write(tmp);
+				}
+			}
+		}());
+		if(e)
+			collectException({writeln(e.msg);}());
+	}
+	void main()
+	{
+		auto listeners = listenTCP(7000,  (conn) @safe nothrow {handleTcp(conn);});
 
-	runApplication();
+		// closes the listening sockets
+		scope (exit)
+			foreach (l; listeners)
+				l.stopListening();
+
+		runApplication();
+	}
+} else {
+	void main()
+	{
+		auto listeners = listenTCP(7000, (conn) @safe nothrow {
+				try pipe(conn, conn);
+				catch (Exception e)
+					logError("Error: %s", e.msg);
+		});
+
+		// closes the listening sockets
+		scope (exit)
+			foreach (l; listeners)
+				l.stopListening();
+
+		runApplication();
+	}
 }
+
+


### PR DESCRIPTION
When using IOMode.once mode, the exception thrown should be a timeout（ReadTimeoutException）, not the default error exception（“Reached end of stream while reading data”）.
I changed the echo-server example to add the "no-pipe" configuration, and I can test it. The original use of once mode, will throw Exception directly, can not determine a read timeout.
 当使用IOMode.once模式时，抛出的异常应该为超时异常，不应该是默认的错误异常。
我更改了 echo-server的例子，添加 “no-pipe” 配置，可以测试。原来使用once模式，会直接抛 Exception，无法判断一次读取超时的。