### PR TITLE
Force struct based FreeListRef construction to be nothrow.

### DIFF
--- a/source/vibe/internal/freelistref.d
+++ b/source/vibe/internal/freelistref.d
@@ -215,7 +215,7 @@ in {
 }
 
 /// Dittor
-private auto internalEmplace(T, Args...)(void[] chunk, auto ref Args args)
+private auto internalEmplace(T, Args...)(void[] chunk, auto ref Args args) nothrow
 	if (!is(T == class))
 in {
 	import std.string, std.format;


### PR DESCRIPTION
The compiler doesn't infer nothrow, possibly due to allocations in the "in" contract.