### PR TITLE
Work around unfair event object behavior in eventcore

### DIFF
--- a/source/vibe/core/taskpool.d
+++ b/source/vibe/core/taskpool.d
@@ -313,7 +313,10 @@ shared final class TaskPool {
 			"Cannot convert arguments '"~ARGS.stringof~"' to function arguments '"~FARGS.stringof~"'.");
 
 		m_state.lock.queue.put(settings, callable, args);
-		m_signal.emitSingle();
+		// NOTE: we need to notify all threads here in order to guarantee proper distribution of
+		//       tasks, as currently the eventcore event implementation does not result in a fair
+		//       scheduling
+		m_signal.emit();
 	}
 
 	private void runTaskDist_unsafe(CALLABLE, ARGS...)(TaskSettings settings, ref CALLABLE callable, ARGS args) // NOTE: no ref for args, to disallow non-copyable types!


### PR DESCRIPTION
The current trigger behavior for "single" notifications sometimes resulted in all tasks ending up in the same worker thread, even if that thread was constantly busy. By notifying all threads, we do introduce a little overhead for each task, but guarantee that a worker thread that is not currently busy takes the task.