### PR TITLE
Fix possible fiber self-call in recycleFiber

### DIFF
--- a/source/vibe/core/core.d
+++ b/source/vibe/core/core.d
@@ -1781,17 +1781,16 @@ private bool getExitFlag()
 package @property bool isEventLoopRunning() @safe nothrow @nogc { return s_eventLoopRunning; }
 package @property ref TaskScheduler taskScheduler() @safe nothrow @nogc { return s_scheduler; }
 
-package void recycleFiber(TaskFiber fiber)
+package bool recycleFiber(TaskFiber fiber)
 @safe nothrow {
-	if (s_availableFibers.length >= s_maxRecycledFibers) {
-		fiber.shutdown();
-		return;
-	}
+	if (s_availableFibers.length >= s_maxRecycledFibers)
+		return false;
 
 	if (s_availableFibers.full)
 		s_availableFibers.capacity = 2 * s_availableFibers.capacity;
 
 	s_availableFibers.put(fiber);
+	return true;
 }
 
 private void setupSignalHandlers()

--- a/source/vibe/core/core.d
+++ b/source/vibe/core/core.d
@@ -1793,6 +1793,21 @@ package bool recycleFiber(TaskFiber fiber)
 	return true;
 }
 
+@safe nothrow unittest { // check fiber recycling and recycling overflow
+	auto tasks = new Task[](s_maxRecycledFibers+1);
+	foreach (i; 0 .. 2) {
+		int nrunning = 0;
+		bool all_running = false;
+		foreach (ref t; tasks) t = runTask({
+			if (++nrunning == tasks.length) all_running = true;
+			while (!all_running)
+				yieldUninterruptible();
+			nrunning--;
+		});
+		foreach (t; tasks) t.joinUninterruptible();
+	}
+}
+
 private void setupSignalHandlers()
 @trusted nothrow {
 	scope (failure) assert(false); // _d_monitorexit is not nothrow

--- a/source/vibe/core/task.d
+++ b/source/vibe/core/task.d
@@ -509,7 +509,8 @@ final package class TaskFiber : Fiber {
 				debug assert(Thread.getThis() is m_thread, "Fiber moved between threads!?");
 
 				// make the fiber available for the next task
-				recycleFiber(this);
+				if (!recycleFiber(this))
+					return;
 			}
 		} catch (UncaughtException th) {
 			th.logException("CoreTaskFiber was terminated unexpectedly");
@@ -555,7 +556,7 @@ final package class TaskFiber : Fiber {
 				try call(Fiber.Rethrow.no);
 				catch (Exception e) assert(false, e.msg);
 			} ();
-		}
+	}
 
 	/** Blocks until the task has ended.
 	*/


### PR DESCRIPTION
Fiber.shutdown() calls Fiber.call(), which will crash if the caller is the same fiber. This now lets the fiber exit itself directly if there is no space for recycling. Regression introduced by e877c5b6690a61026e1e651bebe32e69dccea338.