### PR TITLE
Revert back stdx.allocator -> std.experimental.allocator ?

### DIFF
--- a/source/vibe/internal/allocator.d
+++ b/source/vibe/internal/allocator.d
@@ -1,20 +1,18 @@
 module vibe.internal.allocator;
 
-public import stdx.allocator;
-public import stdx.allocator.building_blocks.allocator_list;
-public import stdx.allocator.building_blocks.null_allocator;
-public import stdx.allocator.building_blocks.region;
-public import stdx.allocator.building_blocks.stats_collector;
-public import stdx.allocator.gc_allocator;
-public import stdx.allocator.mallocator;
+public import std.experimental.allocator;
+public import std.experimental.allocator.building_blocks.allocator_list;
+public import std.experimental.allocator.building_blocks.null_allocator;
+public import std.experimental.allocator.building_blocks.region;
+public import std.experimental.allocator.building_blocks.stats_collector;
+public import std.experimental.allocator.gc_allocator;
+public import std.experimental.allocator.mallocator;
 
-// NOTE: this needs to be used instead of theAllocator due to Phobos issue 17564
-@property IAllocator vibeThreadAllocator()
+alias VibeAllocator = RCIAllocator;
+
+@property VibeAllocator vibeThreadAllocator()
 @safe nothrow @nogc {
-	static IAllocator s_threadAllocator;
-	if (!s_threadAllocator)
-		s_threadAllocator = () @trusted { return allocatorObject(GCAllocator.instance); } ();
-    return s_threadAllocator;
+	return theAllocator();
 }
 
 auto makeGCSafe(T, Allocator, A...)(Allocator allocator, A args)

--- a/source/vibe/internal/array.d
+++ b/source/vibe/internal/array.d
@@ -45,11 +45,11 @@ struct AllocAppender(ArrayType : E[], E) {
 	private {
 		ElemType[] m_data;
 		ElemType[] m_remaining;
-		IAllocator m_alloc;
+		VibeAllocator m_alloc;
 		bool m_allocatedBuffer = false;
 	}
 
-	this(IAllocator alloc, ElemType[] initial_buffer = null)
+	this(VibeAllocator alloc, ElemType[] initial_buffer = null)
 	@safe {
 		m_alloc = alloc;
 		m_data = initial_buffer;


### PR DESCRIPTION
Looks like allocator is stable now and bug is fixed: https://issues.dlang.org/show_bug.cgi?id=17564


History: [Use the stable stdx-allocator DUB package](https://github.com/vibe-d/vibe-core/pull/43)