### PR TITLE
Make formatAlloc inferred as safe

### DIFF
--- a/source/vibe/internal/string.d
+++ b/source/vibe/internal/string.d
@@ -185,8 +185,8 @@ ptrdiff_t matchBracket(string str, bool nested = true)
 string formatAlloc(ARGS...)(IAllocator alloc, string fmt, ARGS args)
 {
 	auto app = AllocAppender!string(alloc);
-	formattedWrite(&app, fmt, args);
-	return app.data;
+	formattedWrite(() @trusted { return &app; } (), fmt, args);
+	return () @trusted { return app.data; } ();
 }
 
 /// Special version of icmp() with optimization for ASCII characters


### PR DESCRIPTION
The version in vibe-d:utils infers as safe and various places rely on that.