### PR TITLE
Make the code work for RCIAllocator

### DIFF
--- a/source/vibe/internal/interfaceproxy.d
+++ b/source/vibe/internal/interfaceproxy.d
@@ -11,14 +11,14 @@ import std.traits : BaseTypeTuple;
 O asInterface(I, O)(O obj) if (is(I == interface) && is(O : I)) { return obj; }
 InterfaceProxyClass!(I, O) asInterface(I, O)(O obj) if (is(I == interface) && !is(O : I)) { return new InterfaceProxyClass!(I, O)(obj); }
 
-InterfaceProxyClass!(I, O) asInterface(I, O)(O obj, IAllocator allocator)
+InterfaceProxyClass!(I, O) asInterface(I, O, Allocator)(O obj, Allocator allocator)
 @trusted if (is(I == interface) && !is(O : I))
 {
 	alias R = InterfaceProxyClass!(I, O);
 	return allocator.makeGCSafe!R(obj);
 }
 
-void freeInterface(I, O)(InterfaceProxyClass!(I, O) inst, IAllocator allocator)
+void freeInterface(I, O, Allocator)(InterfaceProxyClass!(I, O) inst, Allocator allocator)
 {
 	allocator.disposeGCSafe(inst);
 }

--- a/source/vibe/internal/string.d
+++ b/source/vibe/internal/string.d
@@ -182,7 +182,7 @@ ptrdiff_t matchBracket(string str, bool nested = true)
 }
 
 /// Same as std.string.format, just using an allocator.
-string formatAlloc(ARGS...)(IAllocator alloc, string fmt, ARGS args)
+string formatAlloc(Allocator, ARGS...)(Allocator alloc, string fmt, ARGS args)
 {
 	auto app = AllocAppender!string(alloc);
 	formattedWrite(() @trusted { return &app; } (), fmt, args);


### PR DESCRIPTION
Recent versions of std.experimental.allocator are using RCIAllocator instead of IAllocator for passing around allocator objects. This changes the code to accept an arbitrary type to avoid any concrete type dependence.