### PR TITLE
Make TCPConnection/UDPConnection postblit/dtor scope

### DIFF
--- a/source/vibe/core/net.d
+++ b/source/vibe/core/net.d
@@ -549,13 +549,13 @@ struct TCPConnection {
 	}
 
 	this(this)
-	nothrow {
+	scope nothrow {
 		if (m_socket != StreamSocketFD.invalid)
 			eventDriver.sockets.addRef(m_socket);
 	}
 
 	~this()
-	nothrow {
+	scope nothrow {
 		if (m_socket != StreamSocketFD.invalid && m_context && m_context.driver)
 			.releaseHandle!"sockets"(m_socket, m_context.driver);
 	}
@@ -1007,13 +1007,13 @@ struct UDPConnection {
 
 
 	this(this)
-	nothrow {
+	scope nothrow {
 		if (m_socket != DatagramSocketFD.invalid)
 			eventDriver.sockets.addRef(m_socket);
 	}
 
 	~this()
-	nothrow {
+	scope nothrow {
 		if (m_socket != DatagramSocketFD.invalid)
 			releaseHandle!"sockets"(m_socket, m_context.driver);
 	}


### PR DESCRIPTION
While building a project depending on vibe-http,
I got the following deprecation message:
```
vibe-core/source/vibe/core/stream.d(189,7):        scope variable `source` calling non-scope member function `TCPConnection.~this()`
```
Fixing the issue with the destructor shifts it to the postblit, so both needs to be fixed. The same fix was applied to the UDPConnection as a result.