### PR TITLE
Ensure uncaught throwables in task fibers are visible to the user

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -5,7 +5,7 @@ copyright "Copyright © 2016-2020, Sönke Ludwig"
 license "MIT"
 
 dependency "eventcore" version="~>0.9.27"
-dependency "vibe-container" version=">=1.1.0 <2.0.0-0"
+dependency "vibe-container" version=">=1.3.1 <2.0.0-0"
 
 targetName "vibe_core"
 


### PR DESCRIPTION
Prefers logFatal over stderr.writeln so that the error also ends up in log files that may be configured. Also displays a message box for subsystem "windows" executables that don't have a console attached.