### PR TITLE
Make relativeTo work with const paths

### DIFF
--- a/source/vibe/core/path.d
+++ b/source/vibe/core/path.d
@@ -25,7 +25,7 @@ import std.utf : byChar;
 
 	See_also: `relativeToWeb`
 */
-Path relativeTo(Path)(Path path, Path base_path) @safe
+Path relativeTo(Path)(in Path path, in Path base_path) @safe
 	if (isInstanceOf!(GenericPath, Path))
 {
 	import std.array : array, replicate;
@@ -141,6 +141,13 @@ unittest {
 		assert(p1.relativeTo(p2).toString() == "");
 		assert(p2.relativeTo(p2).toString() == "./");
 	}
+
+    {
+        immutable PosixPath p1 = PosixPath("/foo/bar");
+        immutable PosixPath p2 = PosixPath("/foo");
+        immutable PosixPath result = p1.relativeTo(p2);
+        assert(result == PosixPath("bar"));
+    }
 }
 
 nothrow unittest {


### PR DESCRIPTION
Otherwise it results in the following error:
```
source/vibe/core/path.d(69,17): Error: none of the overloads of `__ctor` are callable using a `immutable` object
source/vibe/core/path.d(449,2):        Candidates are: `vibe.core.path.GenericPath!(PosixPathFormat).GenericPath.this(string p)`
source/vibe/core/path.d(461,2):                        `vibe.core.path.GenericPath!(PosixPathFormat).GenericPath.this(Segment segment)`
source/vibe/core/path.d(473,2):                        `__ctor(R)(R segments)`
source/vibe/core/path.d(148,51): Error: template instance `vibe.core.path.relativeTo!(immutable(GenericPath!(PosixPathFormat)))` error instantiating
```

@s-ludwig : This prevents `dub` from merging https://github.com/dlang/dub/pull/2272