### PR TITLE
Fix a regression introduced by #411

### DIFF
--- a/tests/vibe.core.file.d
+++ b/tests/vibe.core.file.d
@@ -27,9 +27,13 @@ void main()
 	f.write(bytes!(6, 7, 8, 9, 10));
 	assert(f.size == 10);
 	assert(f.tell == 10);
+
+	auto fcopy = f;
 	ubyte[5] dst;
-	f.seek(2);
+	fcopy.seek(2);
 	assert(f.tell == 2);
+	fcopy = FileStream.init;
+
 	f.read(dst);
 	assert(f.tell == 7);
 	assert(dst[] == bytes!(3, 4, 5, 6, 7));


### PR DESCRIPTION
Closing of the file stream must only be done when the last reference gets destroyed.

Note that this requires an API addition in eventcore, which is why the code has been wrapped in a static if.