### PR TITLE
Fix bogus FileStream destruction warning.

### DIFF
--- a/source/vibe/core/file.d
+++ b/source/vibe/core/file.d
@@ -701,9 +701,11 @@ scope:
 	nothrow {
 		static if (is(typeof(&eventDriver.files.isUnique))) {
 			if (this.isOpen) {
-				if (m_ctx.driver is (() @trusted => cast(shared)eventDriver)() && eventDriver.files.isUnique(m_fd)) {
-					try close();
-					catch (Exception e) logException(e, "Closing unclosed FileStream during destruction failed");
+				if (m_ctx.driver is (() @trusted => cast(shared)eventDriver)()) {
+					if (eventDriver.files.isUnique(m_fd)) {
+						try close();
+						catch (Exception e) logException(e, "Closing unclosed FileStream during destruction failed");
+					}
 				} else logWarn("Destroying FileStream that is still open in a foreign thread (leaked to GC?). This may lead to crashes.");
 			}
 		}


### PR DESCRIPTION
The warning in its previous form was too general. It is only an actual problem if the last reference to a FileStream is leaked to the GC, as long as it is ensured that the file gets closed before the GC attempts to finalize the last copy, everything is safe.

See #412