### PR TITLE
Improves IPv6 addresses formatting

### DIFF
--- a/source/vibe/core/net.d
+++ b/source/vibe/core/net.d
@@ -507,7 +507,10 @@ struct NetworkAddress {
 	unittest {
 		void test(string ip, string expected = null) {
 			if(expected is null) expected = ip;
-			auto res = () @trusted { return resolveHost(ip, AF_UNSPEC, false); } ().toAddressString();
+			auto w_dns = () @trusted { return resolveHost(ip, AF_UNSPEC, true); } ();
+			auto no_dns = () @trusted { return resolveHost(ip, AF_UNSPEC, false); } ();
+			assert(no_dns == w_dns);
+			auto res = no_dns.toAddressString();
 			assert(res == expected,
 				   "IP "~ip~" yielded wrong string representation: "~res~", expected: "~expected);
 		}


### PR DESCRIPTION
We have lack of support IPv6 addresses formatting, and especially, IPv4 addresses encapsulated into IPv6

[This code](https://github.com/vibe-d/vibe-http/blob/338ecb4b6aeaf6b9f49a9cd1f550c9d670a1299d/source/vibe/http/server.d#L959) is never called and IPv4 addresses on IPv6 interfaces logged as `0:0:0:0:0:ffff:bca2:ee5` instead of `::ffff:188.162.14.229`

I made own implementation because `inet_ntop` from glibc internally does redundand buffer copying, uses stringz, errno and not handles ~~rare `::2` address case~~