### PR TITLE
fix: Make an argument to runWorkerTask nothrow

### DIFF
--- a/tests/issue-58-task-already-scheduled.d
+++ b/tests/issue-58-task-already-scheduled.d
@@ -36,7 +36,7 @@ void main()
 	assert(atomicLoad(counter) == ntasks, "Event loop exited prematurely.");
 }
 
-void worker()
+void worker() nothrow
 {
 	ev.wait(0);
 	ev.emit();


### PR DESCRIPTION
This seems to be the cause of an issue in Buildkite, and looking at the code, there was a deprecation a few months back to force nothrow on delegate arguments, however this does not seem to be caught by the regular CI.