### PR TITLE
GenericPath cleanup

### DIFF
--- a/source/vibe/core/file.d
+++ b/source/vibe/core/file.d
@@ -1134,7 +1134,7 @@ private void performListDirectory(ListDirectoryRequest req)
 					if (fi.isSymlink && !req.followSymlinks)
 						continue;
 					try {
-						if (!scanRec(path ~ NativePath.Segment2(fi.name)))
+						if (!scanRec(path ~ NativePath.Segment(fi.name)))
 							return false;
 					} catch (Exception e) {}
 				}

--- a/source/vibe/core/path.d
+++ b/source/vibe/core/path.d
@@ -723,26 +723,9 @@ struct GenericPath(F) {
 
 	/** Returns the normalized form of the path.
 
-		See `normalize` for a full description.
-	*/
-	@property GenericPath normalized()
-	const {
-		GenericPath ret = this;
-		ret.normalize();
-		return ret;
-	}
-
-	unittest {
-		assert(PosixPath("foo/../bar").normalized == PosixPath("bar"));
-		assert(PosixPath("foo//./bar/../baz").normalized == PosixPath("foo/baz"));
-	}
-
-
-	/** Removes any redundant path segments and replaces all separators by the
-		default one.
-
-		The resulting path representation is suitable for basic semantic
-		comparison to other normalized paths.
+		This removes any redundant path segments and replaces all separators
+		by the default one. The resulting path representation is suitable for
+		basic semantic comparison to other normalized paths.
 
 		Note that there are still ways for different normalized paths to
 		represent the same file. Examples of this are the tilde shortcut to the
@@ -754,8 +737,8 @@ struct GenericPath(F) {
 			segments ("..") that lead to a path that is a parent path of the
 			root path.
 	*/
-	void normalize()
-	{
+	@property GenericPath normalized()
+	const {
 		import std.array : appender, join;
 
 		Segment[] newnodes;
@@ -779,7 +762,28 @@ struct GenericPath(F) {
 
 		auto dst = appender!string;
 		Format.toString(newnodes, dst);
-		m_path = dst.data;
+
+		GenericPath ret;
+		ret.m_path = dst.data;
+		return ret;
+	}
+
+	///
+	unittest {
+		assert(PosixPath("foo/../bar").normalized == PosixPath("bar"));
+		assert(PosixPath("foo//./bar/../baz").normalized == PosixPath("foo/baz"));
+		assert(PosixPath("/foo/../bar").normalized == PosixPath("/bar"));
+		assert(WindowsPath(`\\PC/c$\foo/../bar/`).normalized == WindowsPath(`\\PC\c$\bar\`));
+	}
+
+
+	/** Replaces the path representation with its normalized form.
+
+		See `normalized` for a full description.
+	*/
+	void normalize()
+	{
+		this.m_path = this.normalized.m_path;
 	}
 
 	///

--- a/source/vibe/core/path.d
+++ b/source/vibe/core/path.d
@@ -65,7 +65,7 @@ Path relativeTo(Path)(in Path path, in Path base_path) @safe
 		base++;
 	}
 
-	enum up = Path.Segment2("..", Path.defaultSeparator);
+	enum up = Path.Segment("..", Path.defaultSeparator);
 	auto ret = Path(base_nodes.map!(p => up).chain(nodes));
 	if (path.endsWithSlash) {
 		if (ret.empty) return Path.fromTrustedString("." ~ path.toString()[$-1]);
@@ -216,6 +216,7 @@ struct GenericPath(F) {
 	alias Format = F;
 
 	/// vibe-core 1.x compatibility alias
+	deprecated("Use `Segment` instead.")
 	alias Segment2 = Segment;
 
 	/** A single path segment.
@@ -524,6 +525,7 @@ struct GenericPath(F) {
 	}
 
 	/// vibe-core 1.x compatibility alias
+	deprecated("Use `.bySegment` instead.")
 	alias bySegment2 = bySegment;
 
 	/** Iterates over the individual segments of the path.
@@ -665,6 +667,7 @@ struct GenericPath(F) {
 	}
 
 	// vibe-core 1.x compatibility alias
+	deprecated("Use `.head` instead.")
 	alias head2 = head;
 
 	/// Returns the trailing segment of the path.

--- a/source/vibe/core/path.d
+++ b/source/vibe/core/path.d
@@ -791,7 +791,8 @@ struct GenericPath(F) {
 
 	/** Replaces the path representation with its normalized form.
 
-		See `normalized` for a full description.
+		This is a simple convenience wrapper around the functional style
+		`.normalized`, which is usually preferable.
 	*/
 	void normalize()
 	{


### PR DESCRIPTION
- Swaps the implementation and documentation of `.normalize` and `.normalized`
- Avoids allocations when normalizing an already normalized path
- Deprecates `.Segment2` and associated methods