### PR TITLE
Fix RecursiveMutex to work outside of tasks and make lock() nothrow.

### DIFF
--- a/source/vibe/core/file.d
+++ b/source/vibe/core/file.d
@@ -1218,7 +1218,7 @@ private void performListDirectory(ListDirectoryRequest req)
 					if (fi.isSymlink && !req.followSymlinks)
 						continue;
 					try {
-						if (!scanRec(path ~ NativePath.Segment2(fi.name)))
+						if (!scanRec(path ~ NativePath.Segment(fi.name)))
 							return false;
 					} catch (Exception e) {}
 				}

--- a/source/vibe/core/sync.d
+++ b/source/vibe/core/sync.d
@@ -732,16 +732,16 @@ final class RecursiveTaskMutex : core.sync.mutex.Mutex, Lockable {
 	private shared(RecursiveTaskMutexImpl!false) m_impl;
 
 	// non-shared compatibility API
-	this(Object o) { m_impl.setup(); super(o); }
-	this() { m_impl.setup(); }
+	this(Object o) nothrow { m_impl.setup(); super(o); }
+	this() nothrow { m_impl.setup(); }
 
 	override bool tryLock() nothrow { return m_impl.tryLock(); }
 	override void lock() nothrow { m_impl.lock(); }
 	override void unlock() nothrow { m_impl.unlock(); }
 
 	// new shared API
-	this(Object o) shared { m_impl.setup(); super(o); }
-	this() shared { m_impl.setup(); }
+	this(Object o) shared nothrow { m_impl.setup(); super(o); }
+	this() shared nothrow { m_impl.setup(); }
 
 	override bool tryLock() shared nothrow { return m_impl.tryLock(); }
 	override void lock() shared nothrow { m_impl.lock(); }
@@ -750,6 +750,25 @@ final class RecursiveTaskMutex : core.sync.mutex.Mutex, Lockable {
 
 unittest {
 	runMutexUnitTests!RecursiveTaskMutex();
+}
+
+@safe nothrow unittest {
+	import vibe.core.core : runTask;
+
+	auto m = new RecursiveTaskMutex;
+	m.lock();
+	assert(m.tryLock());
+	m.unlock();
+	runTask({
+		assert(!m.tryLock());
+	}).joinUninterruptible();
+	m.unlock();
+	runTask({
+		assert(m.tryLock());
+		assert(m.tryLock());
+		m.unlock();
+		m.unlock();
+	}).joinUninterruptible();
 }
 
 
@@ -767,7 +786,7 @@ final class InterruptibleRecursiveTaskMutex : Lockable {
 	private shared(RecursiveTaskMutexImpl!true) m_impl;
 
 	this()
-	{
+	nothrow {
 		m_impl.setup();
 
 		// detects invalid usage within synchronized(...)
@@ -779,7 +798,7 @@ final class InterruptibleRecursiveTaskMutex : Lockable {
 	void unlock() nothrow { m_impl.unlock(); }
 
 	this()
-	shared {
+	nothrow shared {
 		m_impl.setup();
 
 		// detects invalid usage within synchronized(...)


### PR DESCRIPTION
Was using Task.getThis() to identify the current lock owner, which would be Task.init outside of a task. Using TaskFiber.getThis() instead, which returns a dummy fiber instance if called outside of a fiber, so that it can be distinguished from TaskFiber.init meaning no owner.