### PR TITLE
Improve logException robustness

### DIFF
--- a/source/vibe/core/log.d
+++ b/source/vibe/core/log.d
@@ -227,8 +227,10 @@ void logException(LogLevel level = LogLevel.error)(Throwable exception,
 	string file = __FILE__, int line = __LINE__)
 @safe nothrow {
 	doLog(level, mod, func, file, line, "%s: %s", error_description, exception.msg);
-	try doLog(LogLevel.diagnostic, mod, func, file, line,
-			  "Full exception: %s", () @trusted { return exception.toString(); } ());
+	try () @trusted {
+		auto diaglvl = min(level, LogLevel.diagnostic);
+		doLog(diaglvl, mod, func, file, line, "%s", exception);
+	} ();
 	catch (Exception e) logDiagnostic("Failed to print full exception: %s", e.msg);
 }
 


### PR DESCRIPTION
Avoids Exception.toString() and instead logs the diagnostic pieces one-by-one, avoiding dynamic memory allocations and and printing out as much as possible in case of a secondary failure during logging.

Also now never logs the diagnostic part of the exception with a log level higher than the main message.