### PR TITLE
Work around DMD 2.111.0/LDC 1.41.0 warning

### DIFF
--- a/source/vibe/core/task.d
+++ b/source/vibe/core/task.d
@@ -39,7 +39,9 @@ struct Task {
 		m_taskCounter = task_counter;
 	}
 
-	this(const Task other)
+	// NOTE: this is a template function to avoid the compiler treating it as a
+	//       move constructor
+	this()(const Task other)
 	@safe nothrow {
 		m_fiber = () @trusted { return cast(shared(TaskFiber))other.m_fiber; } ();
 		m_taskCounter = other.m_taskCounter;


### PR DESCRIPTION
The compiler treats Task.this(const Task) as a move constructor, even when that doesn't really make sense due to the const qualifier. By making this a template function, the constructor is still usable but will not be considered as a move constructor anymore.