### PR TITLE
Add `nothrow` attributes to unittest struct methods

### DIFF
--- a/source/vibe/internal/interfaceproxy.d
+++ b/source/vibe/internal/interfaceproxy.d
@@ -358,9 +358,9 @@ unittest {
 
 	static struct S {
 		int* cnt;
-		this(bool) { cnt = new int; *cnt = 1; }
-		this(this) { if (cnt) (*cnt)++; }
-		~this() { if (cnt) (*cnt)--; }
+		this(bool) nothrow { cnt = new int; *cnt = 1; }
+		this(this) nothrow { if (cnt) (*cnt)++; }
+		~this() nothrow { if (cnt) (*cnt)--; }
 		@property int count() const { return cnt ? *cnt : 0; }
 	}
 


### PR DESCRIPTION
I found a `nothrow` violation when working on DMD: https://buildkite.com/dlang/dmd/builds/45596