### PR TITLE
Expose waitForDataEx

### DIFF
--- a/source/vibe/core/connectionpool.d
+++ b/source/vibe/core/connectionpool.d
@@ -87,10 +87,10 @@ final class ConnectionPool(Connection)
 
 		Connection conn;
 		if( cidx != size_t.max ){
-			logTrace("returning %s connection %d of %d", Connection.stringof, cidx, m_connections.length);
+			logInfo("returning %s connection %d of %d", Connection.stringof, cidx, m_connections.length);
 			conn = m_connections[cidx];
 		} else {
-			logDebug("creating new %s connection, all %d are in use", Connection.stringof, m_connections.length);
+			logInfo("creating new %s connection, all %d are in use", Connection.stringof, m_connections.length);
 			conn = m_connectionFactory(); // NOTE: may block
 			static if (is(typeof(cast(void*)conn)))
 				logDebug(" ... %s", () @trusted { return cast(void*)conn; } ());

--- a/source/vibe/core/net.d
+++ b/source/vibe/core/net.d
@@ -716,6 +716,8 @@ struct TCPConnection {
 	}
 
 	@property int fd() const nothrow { return cast(int)m_socket; }
+	/// Returns the raw StreamSocketFD for use with eventcore operations.
+	@property StreamSocketFD socketFD() const nothrow { return m_socket; }
 
 	bool opCast(T)() const nothrow if (is(T == bool)) { return m_socket != StreamSocketFD.invalid; }
 

--- a/source/vibe/core/net.d
+++ b/source/vibe/core/net.d
@@ -1155,11 +1155,7 @@ enum WaitForDataAsyncStatus {
 	waiting,
 }
 
-enum WaitForDataStatus {
-	dataAvailable,
-	noMoreData,
-	timeout
-}
+
 
 unittest { // test compilation of callback with scoped destruction
 	static struct CB {

--- a/source/vibe/core/net.d
+++ b/source/vibe/core/net.d
@@ -645,15 +645,10 @@ struct TCPConnection {
 	import vibe.internal.array : BatchBuffer;
 	//static assert(isConnectionStream!TCPConnection);
 
-	static struct Context {
-		BatchBuffer!ubyte readBuffer;
-		bool tcpNoDelay = false;
-		bool keepAlive = false;
-		Duration readTimeout = Duration.max;
-		string remoteAddressString;
-		shared(NativeEventDriver) driver;
-
-		// --- Diagnostics for net.d:768-style invariant violations ---------
+	// Diagnostic state for net.d:768-style invariant violations. Heap
+	// allocated and pointed to from Context so that Context itself stays
+	// within eventcore's fixed-size (16*size_t) FD-slot user-data buffer.
+	static struct Diag {
 		// Identity of the call site / fiber that constructed this connection
 		string createdFile;
 		size_t createdLine;
@@ -674,6 +669,16 @@ struct TCPConnection {
 		Throwable.TraceInfo readTrace;
 	}
 
+	static struct Context {
+		BatchBuffer!ubyte readBuffer;
+		bool tcpNoDelay = false;
+		bool keepAlive = false;
+		Duration readTimeout = Duration.max;
+		string remoteAddressString;
+		shared(NativeEventDriver) driver;
+		Diag* diag;
+	}
+
 	private {
 		StreamSocketFD m_socket;
 		Context* m_context;
@@ -688,12 +693,14 @@ struct TCPConnection {
 		m_context = () @trusted { return &eventDriver.sockets.userData!Context(socket); } ();
 		m_context.readBuffer.capacity = 4096;
 		m_context.driver = () @trusted { return cast(shared)eventDriver; } ();
-		m_context.createdFile = file;
-		m_context.createdLine = line;
-		try m_context.createdTask = Task.getThis();
+		if (m_context.diag is null)
+			m_context.diag = new Diag;
+		m_context.diag.createdFile = file;
+		m_context.diag.createdLine = line;
+		try m_context.diag.createdTask = Task.getThis();
 		catch (Exception) {}
-		m_context.createdAt   = MonoTime.currTime;
-		m_context.closeRecorded = false;
+		m_context.diag.createdAt   = MonoTime.currTime;
+		m_context.diag.closeRecorded = false;
 	}
 
 	this(this)
@@ -763,17 +770,18 @@ struct TCPConnection {
 			// The underlying Context lives in eventcore's userData and stays
 			// alive as long as any addRef (e.g. waitForDataEx's inner one)
 			// is held against the FD.
-			if (m_context !is null) {
-				m_context.closedFile = file;
-				m_context.closedLine = line;
-				try m_context.closedTask = Task.getThis();
+			if (m_context !is null && m_context.diag !is null) {
+				auto d = m_context.diag;
+				d.closedFile = file;
+				d.closedLine = line;
+				try d.closedTask = Task.getThis();
 				catch (Exception) {}
-				m_context.closedAt = MonoTime.currTime;
-				m_context.closeRecorded = true;
+				d.closedAt = MonoTime.currTime;
+				d.closeRecorded = true;
 				// Capture a stack trace so the closer can be identified even
 				// when called through wrappers like operations.pipe(),
 				// ConnectionStream.close, HTTPClientResponse.disconnect, etc.
-				try m_context.closedTrace = () @trusted { return defaultTraceHandler(null); } ();
+				try d.closedTrace = () @trusted { return defaultTraceHandler(null); } ();
 				catch (Exception) {}
 			}
 			eventDriver.sockets.shutdown(m_socket, true, true);
@@ -814,14 +822,19 @@ struct TCPConnection {
 		try issuerTask = Task.getThis();
 		catch (Exception) {}
 		auto issuedAt = MonoTime.currTime;
-		m_context.readFile = file;
-		m_context.readLine = line;
-		m_context.readTask = issuerTask;
-		m_context.readIssuedAt = issuedAt;
+		if (m_context.diag is null)
+			m_context.diag = new Diag;
+		{
+			auto d = m_context.diag;
+			d.readFile = file;
+			d.readLine = line;
+			d.readTask = issuerTask;
+			d.readIssuedAt = issuedAt;
+		}
 		Throwable.TraceInfo issuerTrace;
 		try issuerTrace = () @trusted { return defaultTraceHandler(null); } ();
 		catch (Exception) {}
-		m_context.readTrace = issuerTrace;
+		m_context.diag.readTrace = issuerTrace;
 
 		alias waiter = Waitable!(IOCallback,
 			cb => eventDriver.sockets.read(m_socket, m_context.readBuffer.peekDst(), mode, cb),
@@ -839,19 +852,19 @@ struct TCPConnection {
 					try cbTask = Task.getThis();
 					catch (Exception) {}
 					auto ageMs = (MonoTime.currTime - issuedAt).total!"msecs";
+					Diag* d = (m_context !is null) ? m_context.diag : null;
 					long sinceCloseMs = -1;
-					if (m_context !is null && m_context.closeRecorded)
-						sinceCloseMs = (MonoTime.currTime - m_context.closedAt).total!"msecs";
+					if (d !is null && d.closeRecorded)
+						sinceCloseMs = (MonoTime.currTime - d.closedAt).total!"msecs";
 					string readTraceStr = "<unavailable>";
 					if (issuerTrace !is null) {
 						try readTraceStr = () @trusted { return issuerTrace.toString(); } ();
 						catch (Exception) {}
 					}
 					string closeTraceStr = "<no close recorded>";
-					if (m_context !is null && m_context.closeRecorded
-						&& m_context.closedTrace !is null) {
+					if (d !is null && d.closeRecorded && d.closedTrace !is null) {
 						try closeTraceStr = () @trusted {
-							return m_context.closedTrace.toString(); } ();
+							return d.closedTrace.toString(); } ();
 						catch (Exception) {}
 					}
 					logError(
@@ -872,15 +885,15 @@ struct TCPConnection {
 						() @trusted { return cast(void*)m_context; } (),
 						file, line, issuerTask, ageMs,
 						cbTask,
-						(m_context !is null) ? m_context.createdFile : "<context gone>",
-						(m_context !is null) ? m_context.createdLine : 0,
-						(m_context !is null) ? format("%s", m_context.createdTask) : "<unknown>",
-						(m_context !is null && m_context.closeRecorded) ?
+						(d !is null) ? d.createdFile : "<diag gone>",
+						(d !is null) ? d.createdLine : 0,
+						(d !is null) ? format("%s", d.createdTask) : "<unknown>",
+						(d !is null && d.closeRecorded) ?
 							" called at " : " not yet recorded",
-						(m_context !is null && m_context.closeRecorded) ?
-							format("%s:%s", m_context.closedFile, m_context.closedLine) : "",
-						(m_context !is null && m_context.closeRecorded) ?
-							format(" by task %s", m_context.closedTask) : "",
+						(d !is null && d.closeRecorded) ?
+							format("%s:%s", d.closedFile, d.closedLine) : "",
+						(d !is null && d.closeRecorded) ?
+							format(" by task %s", d.closedTask) : "",
 						(sinceCloseMs >= 0) ?
 							format(" %s ms before this callback", sinceCloseMs) : "",
 						readTraceStr,

--- a/source/vibe/core/net.d
+++ b/source/vibe/core/net.d
@@ -15,8 +15,10 @@ import std.socket : AddressFamily, UnknownAddress;
 import vibe.core.internal.release;
 import vibe.core.log;
 import vibe.core.stream;
+import vibe.core.task : Task;
 import vibe.internal.async;
-import core.time : Duration;
+import core.time : Duration, MonoTime;
+import core.runtime : defaultTraceHandler;
 
 @safe:
 
@@ -650,6 +652,26 @@ struct TCPConnection {
 		Duration readTimeout = Duration.max;
 		string remoteAddressString;
 		shared(NativeEventDriver) driver;
+
+		// --- Diagnostics for net.d:768-style invariant violations ---------
+		// Identity of the call site / fiber that constructed this connection
+		string createdFile;
+		size_t createdLine;
+		Task   createdTask;
+		MonoTime createdAt;
+		// Identity of the last close() call (if any)
+		string closedFile;
+		size_t closedLine;
+		Task   closedTask;
+		MonoTime closedAt;
+		bool   closeRecorded;
+		Throwable.TraceInfo closedTrace;
+		// Identity of the most recent waitForDataEx() issuer (if any in flight)
+		string readFile;
+		size_t readLine;
+		Task   readTask;
+		MonoTime readIssuedAt;
+		Throwable.TraceInfo readTrace;
 	}
 
 	private {
@@ -657,7 +679,8 @@ struct TCPConnection {
 		Context* m_context;
 	}
 
-	private this(StreamSocketFD socket, scope RefAddress remote_address)
+	private this(StreamSocketFD socket, scope RefAddress remote_address,
+		string file = __FILE__, size_t line = __LINE__)
 	nothrow {
 		import std.exception : enforce;
 
@@ -665,6 +688,12 @@ struct TCPConnection {
 		m_context = () @trusted { return &eventDriver.sockets.userData!Context(socket); } ();
 		m_context.readBuffer.capacity = 4096;
 		m_context.driver = () @trusted { return cast(shared)eventDriver; } ();
+		m_context.createdFile = file;
+		m_context.createdLine = line;
+		try m_context.createdTask = Task.getThis();
+		catch (Exception) {}
+		m_context.createdAt   = MonoTime.currTime;
+		m_context.closeRecorded = false;
 	}
 
 	this(this)
@@ -725,10 +754,28 @@ struct TCPConnection {
 
 	@property bool dataAvailableForRead() { return waitForData(0.seconds); }
 
-	void close()
+	void close(string file = __FILE__, size_t line = __LINE__)
 	nothrow {
 		//logInfo("close %s", cast(int)m_fd);
 		if (m_socket != StreamSocketFD.invalid) {
+			// Record who closed us, BEFORE clearing m_context, so a later
+			// invariant violation in waitForDataEx can identify the closer.
+			// The underlying Context lives in eventcore's userData and stays
+			// alive as long as any addRef (e.g. waitForDataEx's inner one)
+			// is held against the FD.
+			if (m_context !is null) {
+				m_context.closedFile = file;
+				m_context.closedLine = line;
+				try m_context.closedTask = Task.getThis();
+				catch (Exception) {}
+				m_context.closedAt = MonoTime.currTime;
+				m_context.closeRecorded = true;
+				// Capture a stack trace so the closer can be identified even
+				// when called through wrappers like operations.pipe(),
+				// ConnectionStream.close, HTTPClientResponse.disconnect, etc.
+				try m_context.closedTrace = () @trusted { return defaultTraceHandler(null); } ();
+				catch (Throwable) {}
+			}
 			eventDriver.sockets.shutdown(m_socket, true, true);
 			eventDriver.sockets.releaseRef(m_socket);
 			m_socket = StreamSocketFD.invalid;
@@ -736,12 +783,14 @@ struct TCPConnection {
 		}
 	}
 
-	bool waitForData(Duration timeout = Duration.max)
+	bool waitForData(Duration timeout = Duration.max,
+		string file = __FILE__, size_t line = __LINE__)
 	{
-		return waitForDataEx(timeout) == WaitForDataStatus.dataAvailable;
+		return waitForDataEx(timeout, file, line) == WaitForDataStatus.dataAvailable;
 	}
 
-	WaitForDataStatus waitForDataEx(Duration timeout = Duration.max)
+	WaitForDataStatus waitForDataEx(Duration timeout = Duration.max,
+		string file = __FILE__, size_t line = __LINE__)
 	{
 		mixin(tracer);
 		if (!m_context) return WaitForDataStatus.noMoreData;
@@ -757,15 +806,89 @@ struct TCPConnection {
 		eventDriver.sockets.addRef(m_socket);
 		scope (exit) eventDriver.sockets.releaseRef(sock);
 
+		// Record the issuer of this read for diagnostics on a later
+		// invariant violation (m_socket changing under us). The stack trace
+		// captures the full call chain (e.g. operations.pipe -> bodyReader
+		// -> waitForDataEx) so wrappers like proxy pipe() can be identified.
+		Task issuerTask;
+		try issuerTask = Task.getThis();
+		catch (Exception) {}
+		auto issuedAt = MonoTime.currTime;
+		m_context.readFile = file;
+		m_context.readLine = line;
+		m_context.readTask = issuerTask;
+		m_context.readIssuedAt = issuedAt;
+		Throwable.TraceInfo issuerTrace;
+		try issuerTrace = () @trusted { return defaultTraceHandler(null); } ();
+		catch (Throwable) {}
+		m_context.readTrace = issuerTrace;
+
 		alias waiter = Waitable!(IOCallback,
 			cb => eventDriver.sockets.read(m_socket, m_context.readBuffer.peekDst(), mode, cb),
 			(cb) { cancelled = true; eventDriver.sockets.cancelRead(m_socket); },
-			(sock, st, nb) {
-				if (m_socket == StreamSocketFD.invalid) {
-					cancelled = true;
-					return;
+			(sock_cb, st, nb) {
+				// Identity invariant: the FD captured before the await (`sock`)
+				// must still match both the field (m_socket) and the FD that
+				// eventcore is delivering the completion for (sock_cb). If any
+				// of these disagree, somebody closed or aliased this connection
+				// across fibers — log everything we know about both ends and
+				// then abort, since proceeding past this point is unsafe (the
+				// readBuffer may have been written by a foreign FD).
+				if (m_socket != sock || sock_cb != sock) {
+					Task cbTask;
+					try cbTask = Task.getThis();
+					catch (Exception) {}
+					auto ageMs = (MonoTime.currTime - issuedAt).total!"msecs";
+					long sinceCloseMs = -1;
+					if (m_context !is null && m_context.closeRecorded)
+						sinceCloseMs = (MonoTime.currTime - m_context.closedAt).total!"msecs";
+					string readTraceStr = "<unavailable>";
+					if (issuerTrace !is null) {
+						try readTraceStr = () @trusted { return issuerTrace.toString(); } ();
+						catch (Throwable) {}
+					}
+					string closeTraceStr = "<no close recorded>";
+					if (m_context !is null && m_context.closeRecorded
+						&& m_context.closedTrace !is null) {
+						try closeTraceStr = () @trusted {
+							return m_context.closedTrace.toString(); } ();
+						catch (Throwable) {}
+					}
+					logError(
+						"TCPConnection.waitForDataEx: m_socket invariant violated.\n"
+						~ "  captured sock = %s\n"
+						~ "  current m_socket = %s\n"
+						~ "  callback sock = %s\n"
+						~ "  IOStatus = %s, nbytes = %s\n"
+						~ "  m_context = %s\n"
+						~ "  read issued at %s:%s by task %s, %s ms ago\n"
+						~ "  callback delivered to task %s\n"
+						~ "  connection created at %s:%s by task %s\n"
+						~ "  close()%s%s%s%s\n"
+						~ "  --- read issuer trace ---\n%s\n"
+						~ "  --- closer trace ---\n%s",
+						cast(int)sock, cast(int)m_socket, cast(int)sock_cb,
+						st, nb,
+						() @trusted { return cast(void*)m_context; } (),
+						file, line, issuerTask, ageMs,
+						cbTask,
+						(m_context !is null) ? m_context.createdFile : "<context gone>",
+						(m_context !is null) ? m_context.createdLine : 0,
+						(m_context !is null) ? format("%s", m_context.createdTask) : "<unknown>",
+						(m_context !is null && m_context.closeRecorded) ?
+							" called at " : " not yet recorded",
+						(m_context !is null && m_context.closeRecorded) ?
+							format("%s:%s", m_context.closedFile, m_context.closedLine) : "",
+						(m_context !is null && m_context.closeRecorded) ?
+							format(" by task %s", m_context.closedTask) : "",
+						(sinceCloseMs >= 0) ?
+							format(" %s ms before this callback", sinceCloseMs) : "",
+						readTraceStr,
+						closeTraceStr);
+					assert(false, "TCPConnection.waitForDataEx: m_socket changed "
+						~ "under in-flight read; see log above for issuer/closer.");
 				}
-				assert(sock == m_socket); status = st; nbytes = nb;
+				status = st; nbytes = nb;
 			}
 		);
 

--- a/source/vibe/core/net.d
+++ b/source/vibe/core/net.d
@@ -836,6 +836,14 @@ struct TCPConnection {
 		catch (Exception) {}
 		m_context.diag.readTrace = issuerTrace;
 
+		// Capture pointers to the Context (lives in eventcore's userData,
+		// kept alive by our addRef above) and Diag (GC-rooted via the slot)
+		// so that, even if a concurrent close() zeroes m_socket / m_context
+		// on this struct, we can still recover the closer's identity in the
+		// callback below.
+		auto ctxBefore  = m_context;
+		auto diagBefore = m_context.diag;
+
 		alias waiter = Waitable!(IOCallback,
 			cb => eventDriver.sockets.read(m_socket, m_context.readBuffer.peekDst(), mode, cb),
 			(cb) { cancelled = true; eventDriver.sockets.cancelRead(m_socket); },
@@ -852,7 +860,11 @@ struct TCPConnection {
 					try cbTask = Task.getThis();
 					catch (Exception) {}
 					auto ageMs = (MonoTime.currTime - issuedAt).total!"msecs";
-					Diag* d = (m_context !is null) ? m_context.diag : null;
+					// Prefer the captured-before-await pointers: m_context may
+					// have been zeroed by a concurrent close(), but the slot
+					// itself is kept alive by the addRef we made before await.
+					Diag* d = diagBefore;
+					if (d is null && m_context !is null) d = m_context.diag;
 					long sinceCloseMs = -1;
 					if (d !is null && d.closeRecorded)
 						sinceCloseMs = (MonoTime.currTime - d.closedAt).total!"msecs";
@@ -873,7 +885,7 @@ struct TCPConnection {
 						~ "  current m_socket = %s\n"
 						~ "  callback sock = %s\n"
 						~ "  IOStatus = %s, nbytes = %s\n"
-						~ "  m_context = %s\n"
+						~ "  m_context (current) = %s; (before await) = %s\n"
 						~ "  read issued at %s:%s by task %s, %s ms ago\n"
 						~ "  callback delivered to task %s\n"
 						~ "  connection created at %s:%s by task %s\n"
@@ -883,6 +895,7 @@ struct TCPConnection {
 						cast(int)sock, cast(int)m_socket, cast(int)sock_cb,
 						st, nb,
 						() @trusted { return cast(void*)m_context; } (),
+						() @trusted { return cast(void*)ctxBefore; } (),
 						file, line, issuerTask, ageMs,
 						cbTask,
 						(d !is null) ? d.createdFile : "<diag gone>",

--- a/source/vibe/core/net.d
+++ b/source/vibe/core/net.d
@@ -774,7 +774,7 @@ struct TCPConnection {
 				// when called through wrappers like operations.pipe(),
 				// ConnectionStream.close, HTTPClientResponse.disconnect, etc.
 				try m_context.closedTrace = () @trusted { return defaultTraceHandler(null); } ();
-				catch (Throwable) {}
+				catch (Exception) {}
 			}
 			eventDriver.sockets.shutdown(m_socket, true, true);
 			eventDriver.sockets.releaseRef(m_socket);
@@ -820,7 +820,7 @@ struct TCPConnection {
 		m_context.readIssuedAt = issuedAt;
 		Throwable.TraceInfo issuerTrace;
 		try issuerTrace = () @trusted { return defaultTraceHandler(null); } ();
-		catch (Throwable) {}
+		catch (Exception) {}
 		m_context.readTrace = issuerTrace;
 
 		alias waiter = Waitable!(IOCallback,
@@ -845,14 +845,14 @@ struct TCPConnection {
 					string readTraceStr = "<unavailable>";
 					if (issuerTrace !is null) {
 						try readTraceStr = () @trusted { return issuerTrace.toString(); } ();
-						catch (Throwable) {}
+						catch (Exception) {}
 					}
 					string closeTraceStr = "<no close recorded>";
 					if (m_context !is null && m_context.closeRecorded
 						&& m_context.closedTrace !is null) {
 						try closeTraceStr = () @trusted {
 							return m_context.closedTrace.toString(); } ();
-						catch (Throwable) {}
+						catch (Exception) {}
 					}
 					logError(
 						"TCPConnection.waitForDataEx: m_socket invariant violated.\n"

--- a/source/vibe/core/stream.d
+++ b/source/vibe/core/stream.d
@@ -351,6 +351,16 @@ interface Stream : InputStream, OutputStream {
 
 	See_also: `vibe.core.net.TCPConnection`
 */
+/** Three-state return value for `waitForDataEx`.
+
+	See_also: `ConnectionStream.waitForDataEx`
+*/
+enum WaitForDataStatus {
+	dataAvailable,
+	noMoreData,
+	timeout
+}
+
 interface ConnectionStream : Stream {
 	@safe:
 
@@ -386,6 +396,21 @@ interface ConnectionStream : Stream {
 			If the connection gets closed, or the timeout gets reached, `false` is returned instead.
 	*/
 	bool waitForData(Duration timeout = Duration.max) @blocking;
+
+	/** Three-state version of `waitForData` that distinguishes data, EOF, and timeout.
+
+		Params:
+			timeout = Optional timeout, the default value of `Duration.max` waits without a timeout.
+
+		Returns:
+			A `WaitForDataStatus` value:
+			$(UL
+				$(LI `dataAvailable` — new data is available for reading)
+				$(LI `noMoreData` — the connection has been closed (EOF))
+				$(LI `timeout` — the specified timeout was reached)
+			)
+	*/
+	WaitForDataStatus waitForDataEx(Duration timeout = Duration.max) @blocking;
 }
 
 


### PR DESCRIPTION
This PR is necessary for others in vibe-stream and vibe-http.
To implement bidirectional tunnel in proxy.d correctly without closing a socket from a different fiber than the one that owns it. 
If a socket is closed by a fiber that doesn't own it, a fatal assert is triggered in net.d:768, on occasion during high load.